### PR TITLE
incorporate TreeViewer, migrate PersistenceService et al.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,4 +17,4 @@
     <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
-
+<app-test-navigator></app-test-navigator>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,13 +1,23 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { TestNavigatorComponent } from './modules/test-navigator/test-navigator.component';
+import { MessagingModule } from '@testeditor/messaging-service';
+import { HttpProviderService } from './modules/http-provider-service/http-provider.service';
+import { PersistenceService } from './modules/persistence-service/persistence.service';
+import { PersistenceServiceConfig } from './modules/persistence-service/persistence.service.config';
+import { TreeViewerModule } from '@testeditor/testeditor-commons';
+import { TreeFilterService } from './modules/tree-filter-service/tree-filter.service';
 describe('AppComponent', () => {
   beforeEach(async(() => {
+    const persistenceServiceConfig: PersistenceServiceConfig = { persistenceServiceUrl: 'http://example.org' };
     TestBed.configureTestingModule({
+      imports: [ MessagingModule.forRoot(), TreeViewerModule ],
       declarations: [
         AppComponent,
         TestNavigatorComponent
       ],
+      providers: [ HttpProviderService, TreeFilterService, PersistenceService,
+        { provide: PersistenceServiceConfig, useValue: persistenceServiceConfig } ]
     }).compileComponents();
   }));
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,17 +4,22 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 import { TestNavigatorModule } from './modules/test-navigator/test-navigator.module';
-
+import { MessagingModule } from '@testeditor/messaging-service';
+import { PersistenceServiceMock } from './persistence.service.mock';
+import { PersistenceService } from './modules/persistence-service/persistence.service';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
 
 @NgModule({
   declarations: [
     AppComponent
   ],
   imports: [
+    HttpClientModule,
     BrowserModule,
-    TestNavigatorModule
+    TestNavigatorModule.forRoot( { persistenceServiceUrl: 'http://localhost:9080' } ),
+    MessagingModule.forRoot()
   ],
-  providers: [],
+  providers: [HttpClient, {provide: PersistenceService, useClass: PersistenceServiceMock}],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/modules/event-types.ts
+++ b/src/app/modules/event-types.ts
@@ -1,0 +1,2 @@
+export const HTTP_CLIENT_NEEDED = 'httpClient.needed';
+export const HTTP_CLIENT_SUPPLIED = 'httpClient.supplied';

--- a/src/app/modules/http-provider-service/http-provider.service.spec.ts
+++ b/src/app/modules/http-provider-service/http-provider.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed, inject, fakeAsync } from '@angular/core/testing';
+
+import { HttpProviderService } from './http-provider.service';
+import { MessagingService, MessagingModule } from '@testeditor/messaging-service';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+describe('HttpProviderService', () => {
+  let messagingService: MessagingService;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        HttpClientModule,
+        MessagingModule.forRoot()
+      ],
+      providers: [HttpProviderService]
+    });
+    messagingService = TestBed.get(MessagingService);
+    httpClient = TestBed.get(HttpClient);
+
+    const subscription = messagingService.subscribe('httpClient.needed', () => {
+      subscription.unsubscribe();
+      messagingService.publish('httpClient.supplied', { httpClient: httpClient });
+    });
+  });
+
+  it('should be created', inject([HttpProviderService], (service: HttpProviderService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should return http client', fakeAsync(inject([HttpProviderService], (serviceUnderTest: HttpProviderService) => {
+    // when
+    const httpPromise = serviceUnderTest.getHttpClient();
+
+    // then
+    httpPromise.then((actualClient) => {
+      expect(actualClient).toEqual(httpClient);
+    });
+  })));
+
+  it('should use cached value', fakeAsync(inject([HttpProviderService], (serviceUnderTest: HttpProviderService) => {
+    // given
+    serviceUnderTest.getHttpClient().then(() => {
+      let calledSecondTime = false;
+      const subscription = messagingService.subscribe('httpClient.needed', () => {
+        subscription.unsubscribe();
+        calledSecondTime = true;
+        messagingService.publish('httpClient.supplied', { httpClient: httpClient });
+      });
+
+      // when
+      const secondHttpPromise = serviceUnderTest.getHttpClient();
+
+      // then
+      expect(calledSecondTime).toBeFalsy();
+      secondHttpPromise.then((actualClient) => {
+        expect(actualClient).toEqual(httpClient);
+      });
+    });
+  })));
+});

--- a/src/app/modules/http-provider-service/http-provider.service.ts
+++ b/src/app/modules/http-provider-service/http-provider.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { MessagingService } from '@testeditor/messaging-service';
+import { HTTP_CLIENT_NEEDED, HTTP_CLIENT_SUPPLIED } from '../event-types';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/bindCallback';
+
+@Injectable()
+export class HttpProviderService {
+
+  private httpClientPromise: Promise<HttpClient>;
+  private httpClient: HttpClient;
+
+  constructor(private messagingService: MessagingService) {
+    const getObservable = Observable.bindCallback(this.retrieveHttpClient, (client: HttpClient) => client);
+    this.httpClientPromise = getObservable(this.messagingService).toPromise();
+  }
+
+  async getHttpClient(): Promise<HttpClient> {
+    if (!this.httpClient) {
+        this.messagingService.publish(HTTP_CLIENT_NEEDED, null);
+        this.httpClient = await this.httpClientPromise;
+    }
+
+    return this.httpClient;
+  }
+
+  private retrieveHttpClient(messagingService: MessagingService, callback: (client: HttpClient) => void): void {
+    const responseSubscription = messagingService.subscribe(HTTP_CLIENT_SUPPLIED, (httpClientPayload) => {
+      responseSubscription.unsubscribe();
+      callback(httpClientPayload.httpClient);
+    });
+  }
+
+}

--- a/src/app/modules/model/test-navigator-tree-node.spec.ts
+++ b/src/app/modules/model/test-navigator-tree-node.spec.ts
@@ -1,0 +1,54 @@
+import { TestNavigatorTreeNode } from './test-navigator-tree-node';
+import { ElementType, WorkspaceElement } from '../persistence-service/workspace-element';
+
+describe('TestNavigatorTreeNode', () => {
+  it('should create an instance', () => {
+    expect(new TestNavigatorTreeNode({name: 'anElement', path: 'path/to/anElement', type: ElementType.File, children: []})).toBeTruthy();
+  });
+
+  it('should properly fill TestNavigatorTreeNode fields', () => {
+    // given
+    const workspaceTree: WorkspaceElement = {
+      name: 'root',
+      path: 'path/to/root',
+      type: ElementType.Folder,
+      children: []
+    };
+
+    // when
+    const actualTreeNode = new TestNavigatorTreeNode(workspaceTree);
+
+    // then
+    expect(actualTreeNode.collapsedCssClasses).toEqual('fas fa-chevron-right');
+    expect(actualTreeNode.children.length).toEqual(0);
+    expect(actualTreeNode.expandedCssClasses).toEqual('fas fa-chevron-down');
+    expect(actualTreeNode.hover).toEqual(workspaceTree.name);
+    expect(actualTreeNode.id).toEqual(workspaceTree.path);
+    expect(actualTreeNode.leafCssClasses).toEqual('fas fa-folder');
+    expect(actualTreeNode.name).toEqual(workspaceTree.name);
+  });
+
+  it('should recurse into children', () => {
+    // given
+    const workspaceTree: WorkspaceElement = {
+      name: 'root',
+      path: 'path/to/root',
+      type: ElementType.Folder,
+      children: [{
+        name: 'child',
+        path: 'path/to/root/child',
+        type: ElementType.File,
+        children: []
+      }]
+    };
+
+    // when
+    const actualTreeNode = new TestNavigatorTreeNode(workspaceTree);
+
+    // then
+    expect(actualTreeNode.children).toBeTruthy();
+    expect(actualTreeNode.children.length).toEqual(1);
+    expect(actualTreeNode.children[0].name).toEqual(workspaceTree.children[0].name);
+    expect(actualTreeNode.children[0].id).toEqual(workspaceTree.children[0].path);
+  });
+});

--- a/src/app/modules/model/test-navigator-tree-node.ts
+++ b/src/app/modules/model/test-navigator-tree-node.ts
@@ -1,0 +1,63 @@
+import { TreeNode } from '@testeditor/testeditor-commons';
+import { WorkspaceElement, ElementType } from '../persistence-service/workspace-element';
+
+export class TestNavigatorTreeNode implements TreeNode {
+  private static readonly folderCssClass = 'fas fa-folder';
+  private static readonly unknownFileCssClass = 'fas fa-question';
+  private static readonly extensionToCssClass = {
+    'bmp': 'fas fas fa-image', 'png': 'fas fa-image', 'jpg': 'fas fa-image', 'jpeg': 'fas fa-image', 'gif': 'fas fa-image',
+    'svg': 'fas fa-image', 'tsl': 'fas fa-file', 'tcl': 'fas fa-file', 'tml': 'fas fa-file', 'config': 'fas fa-file', 'aml': 'fas fa-file'};
+
+  private _children: TestNavigatorTreeNode[];
+  collapsedCssClasses = 'fas fa-chevron-right';
+  expandedCssClasses = 'fas fa-chevron-down';
+  leafCssClasses: string;
+
+  constructor(private workspaceElement: WorkspaceElement) {
+    switch (workspaceElement.type) {
+      case ElementType.File: this.leafCssClasses = this.leafCssClassesForFile(workspaceElement.name); break;
+      case ElementType.Folder: this.leafCssClasses = TestNavigatorTreeNode.folderCssClass;
+    }
+  }
+
+  get name(): string {
+    return this.workspaceElement.name;
+  }
+
+  get hover(): string {
+    return this.workspaceElement.name;
+  }
+
+  get id(): string {
+    return this.workspaceElement.path;
+  }
+
+  get children(): TreeNode[] {
+    if (!this._children) {
+      if (this.workspaceElement.children) {
+        this._children = this.workspaceElement.children.map((element) => new TestNavigatorTreeNode(element))
+          .sort((nodeA, nodeB) => {
+            return nodeA.name.localeCompare(nodeB.name);
+          });
+      } else {
+        this._children = [];
+      }
+
+    }
+    return this._children;
+  }
+
+  private leafCssClassesForFile(fileName: string): string {
+    let cssClasses = TestNavigatorTreeNode.unknownFileCssClass;
+
+    // get file extension, or empty string if file has no extension
+    // https://stackoverflow.com/questions/190852/how-can-i-get-file-extensions-with-javascript#answer-12900504
+    const extension = fileName.slice((Math.max(0, fileName.lastIndexOf('.')) || Infinity) + 1);
+
+    if ((extension && TestNavigatorTreeNode.extensionToCssClass[extension])) {
+      cssClasses = TestNavigatorTreeNode.extensionToCssClass[extension];
+    }
+
+    return cssClasses;
+  }
+}

--- a/src/app/modules/persistence-service/conflict.ts
+++ b/src/app/modules/persistence-service/conflict.ts
@@ -1,0 +1,7 @@
+export class Conflict {
+  constructor(readonly message: string, readonly backupFilePath?: string) { }
+}
+
+export function isConflict(conflict: Conflict | string): conflict is Conflict {
+  return (<Conflict>conflict).message !== undefined;
+}

--- a/src/app/modules/persistence-service/persistence.service.config.ts
+++ b/src/app/modules/persistence-service/persistence.service.config.ts
@@ -1,0 +1,5 @@
+export class PersistenceServiceConfig {
+
+  persistenceServiceUrl: string;
+
+}

--- a/src/app/modules/persistence-service/persistence.service.spec.ts
+++ b/src/app/modules/persistence-service/persistence.service.spec.ts
@@ -1,0 +1,112 @@
+import { PersistenceServiceConfig } from './persistence.service.config';
+import { PersistenceService } from './persistence.service';
+import { HttpClientModule, HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
+import { inject, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { fakeAsync } from '@angular/core/testing';
+import { MessagingService, MessagingModule } from '@testeditor/messaging-service';
+import { Conflict } from './conflict';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+
+describe('PersistenceService', () => {
+  let serviceConfig: PersistenceServiceConfig;
+  let messagingService: MessagingService;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    serviceConfig = new PersistenceServiceConfig();
+    serviceConfig.persistenceServiceUrl = 'http://localhost:9080';
+
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        HttpClientTestingModule,
+        MessagingModule.forRoot()
+      ],
+      providers: [
+        { provide: PersistenceServiceConfig, useValue: serviceConfig },
+        PersistenceService,
+        HttpClient,
+        HttpProviderService
+      ]
+    });
+
+    messagingService = TestBed.get(MessagingService);
+    httpClient = TestBed.get(HttpClient);
+
+    const subscription = messagingService.subscribe('httpClient.needed', () => {
+      subscription.unsubscribe();
+      messagingService.publish('httpClient.supplied', { httpClient: httpClient });
+    });
+  });
+
+  it('invokes REST endpoint with encoded path', fakeAsync(inject([HttpTestingController, PersistenceService],
+    (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
+    // given
+    const tclFilePath = 'path/to/file?.tcl';
+
+    // when
+    persistenceService.deleteResource(tclFilePath)
+
+    // then
+    .then((response) => expect(response).toBe(''));
+    tick();
+
+    httpMock.match({
+      method: 'DELETE',
+      url: serviceConfig.persistenceServiceUrl + '/documents/path/to/file%3F.tcl'
+    })[0].flush('');
+  })));
+
+  it('createResource returns Conflict object if HTTP status code is CONFLICT', fakeAsync(
+    inject([HttpTestingController, PersistenceService],
+    (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
+    // given
+    const tclFilePath = 'path/to/file.tcl';
+    const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
+    const message = `The file '${tclFilePath}' already exists.`;
+    // const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
+
+    const expectedResult = new Conflict(message);
+
+    // when
+    persistenceService.createResource(tclFilePath, 'file')
+
+    // then
+    .then((actualResult) => expect(actualResult).toEqual(expectedResult));
+    tick();
+
+    const actualRequest = httpMock.expectOne({ method: 'POST' });
+    expect(actualRequest.request.url).toEqual(url);
+    expect(actualRequest.request.params.get('type')).toEqual('file');
+    actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
+    })));
+
+  it('deleteResource returns Conflict object if HTTP status code is CONFLICT',
+    fakeAsync(inject([HttpTestingController, PersistenceService],
+    (httpMock: HttpTestingController, persistenceService: PersistenceService) => {
+    // given
+    const tclFilePath = 'path/to/file.tcl';
+    const url = `${serviceConfig.persistenceServiceUrl}/documents/${tclFilePath}`;
+    const message = `The file '${tclFilePath}' does not exist.`;
+    const mockResponse = new HttpResponse({ body: message, status: 409, statusText: 'Conflict' });
+
+    const expectedResult = new Conflict(message);
+
+    // when
+    persistenceService.deleteResource(tclFilePath)
+
+    // then
+    .then((result) => {
+        expect(result).toEqual(expectedResult);
+      }, (response) => {
+        fail('expect conflict to be remapped to regular response!');
+      });
+    tick();
+
+    const actualRequest = httpMock.expectOne({ method: 'DELETE' });
+    expect(actualRequest.request.url).toEqual(url);
+    actualRequest.flush(message, {status: 409, statusText: 'Conflict'});
+  })));
+});

--- a/src/app/modules/persistence-service/persistence.service.ts
+++ b/src/app/modules/persistence-service/persistence.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { WorkspaceElement } from './workspace-element';
+import { PersistenceServiceConfig } from './persistence.service.config';
+import { Conflict } from './conflict';
+import 'rxjs/add/operator/toPromise';
+import { MessagingService } from '@testeditor/messaging-service';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { HttpResponse } from 'selenium-webdriver/http';
+
+// code duplication with test execution service and test-editor-web, removal planned with next refactoring
+const HTTP_CLIENT_NEEDED = 'httpClient.needed';
+const HTTP_CLIENT_SUPPLIED = 'httpClient.supplied';
+
+export const HTTP_STATUS_NO_CONTENT = 204;
+export const HTTP_STATUS_CONFLICT = 409;
+export const HTTP_HEADER_CONTENT_LOCATION = 'content-location';
+
+export abstract class AbstractPersistenceService {
+  abstract listFiles(): Promise<WorkspaceElement>;
+  abstract renameResource(newPath: string, oldPath: string): Promise<string | Conflict>;
+  abstract deleteResource(path: string): Promise<string | Conflict>;
+  abstract createResource(path: string, type: string): Promise<string | Conflict>;
+  abstract getBinaryResource(path: string): Promise<Blob>;
+}
+
+@Injectable()
+export class PersistenceService extends AbstractPersistenceService {
+
+  private serviceUrl: string;
+  private listFilesUrl: string;
+
+  private cachedHttpClient: HttpClient;
+
+  constructor(config: PersistenceServiceConfig, private httpProvider: HttpProviderService) {
+    super();
+    this.serviceUrl = config.persistenceServiceUrl;
+    this.listFilesUrl = `${config.persistenceServiceUrl}/workspace/list-files`;
+  }
+
+  async listFiles(): Promise<WorkspaceElement> {
+    const client = await this.httpProvider.getHttpClient();
+    return await client.get<WorkspaceElement>(this.listFilesUrl).toPromise();
+  }
+
+  async renameResource(newPath: string, oldPath: string): Promise<string | Conflict> {
+    const client = await this.httpProvider.getHttpClient();
+    try {
+      return (await client.put(this.getRenameURL(oldPath), newPath, { observe: 'response', responseType: 'text'}).toPromise()).body;
+    } catch (errorResponse) {
+      return this.getConflictOrThrowError(errorResponse);
+    }
+  }
+
+  async deleteResource(path: string): Promise<string | Conflict> {
+    const client = await this.httpProvider.getHttpClient();
+    try {
+      return (await client.delete(this.getURL(path), { observe: 'response', responseType: 'text'}).toPromise()).body;
+    } catch (errorResponse) {
+      return this.getConflictOrThrowError(errorResponse);
+    }
+  }
+
+  async createResource(path: string, type: string): Promise<string | Conflict> {
+    const client = await this.httpProvider.getHttpClient();
+    try {
+      return (await client.post(this.getURL(path), '', { observe: 'response', responseType: 'text', params: { type: type } })
+        .toPromise()).body;
+    } catch (errorResponse) {
+      return this.getConflictOrThrowError(errorResponse);
+    }
+  }
+
+  async getBinaryResource(path: string): Promise<Blob> {
+    const client = await this.httpProvider.getHttpClient();
+    return await client.get(this.getURL(path), { responseType: 'blob' }).toPromise();
+  }
+
+  private getRenameURL(path: string): string {
+    return this.getURL(path) + '?rename';
+  }
+
+  private getURL(path: string): string {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    return `${this.serviceUrl}/documents/${encodedPath}`;
+  }
+
+  private getConflictOrThrowError(errorResponse: HttpErrorResponse | any): Conflict {
+    if (this.isHttpErrorResponse(errorResponse)) {
+      if (errorResponse.status === HTTP_STATUS_CONFLICT) {
+        return new Conflict(errorResponse.error);
+      } else {
+        throw new Error(errorResponse.error);
+      }
+    } else {
+      throw errorResponse;
+    }
+  }
+
+  private isHttpErrorResponse(response: HttpErrorResponse | any): response is HttpErrorResponse {
+    return (<HttpErrorResponse>response).status !== undefined && (<HttpErrorResponse>response).error !== undefined;
+  }
+
+}

--- a/src/app/modules/persistence-service/workspace-element.ts
+++ b/src/app/modules/persistence-service/workspace-element.ts
@@ -1,0 +1,11 @@
+export class WorkspaceElement {
+  name: string;
+  path: string;
+  type: ElementType;
+  children: WorkspaceElement[];
+}
+
+export enum ElementType {
+  File = 'file',
+  Folder = 'folder'
+}

--- a/src/app/modules/test-navigator/test-navigator.component.html
+++ b/src/app/modules/test-navigator/test-navigator.component.html
@@ -1,3 +1,1 @@
-<p>
-  test-navigator works!
-</p>
+<app-tree-viewer [model]="model" [level]="0" [config]="treeConfig"></app-tree-viewer>

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -1,13 +1,23 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TestNavigatorComponent } from './test-navigator.component';
+import { TreeViewerModule } from '@testeditor/testeditor-commons';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { MessagingModule } from '@testeditor/messaging-service';
+import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
 
 describe('TestNavigatorComponent', () => {
   let component: TestNavigatorComponent;
   let fixture: ComponentFixture<TestNavigatorComponent>;
 
   beforeEach(async(() => {
+    const persistenceServiceConfig: PersistenceServiceConfig = { persistenceServiceUrl: 'http://example.org' };
     TestBed.configureTestingModule({
-      declarations: [ TestNavigatorComponent ]
+      imports: [ TreeViewerModule, MessagingModule.forRoot() ],
+      declarations: [ TestNavigatorComponent ],
+      providers: [ HttpProviderService, TreeFilterService, PersistenceService,
+        { provide: PersistenceServiceConfig, useValue: persistenceServiceConfig } ]
     })
     .compileComponents();
   }));

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { TestNavigatorTreeNode } from '../model/test-navigator-tree-node';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
+import { TreeViewerConfig, TreeNode } from '@testeditor/testeditor-commons';
 
 @Component({
   selector: 'app-test-navigator',
@@ -6,10 +10,22 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./test-navigator.component.css']
 })
 export class TestNavigatorComponent implements OnInit {
+  model: TestNavigatorTreeNode;
+  treeConfig: TreeViewerConfig = {
+    onClick: () => null,
+    onDoubleClick: (node: TreeNode) => node.expanded = !node.expanded,
+    onIconClick: (node: TreeNode) => node.expanded = !node.expanded
+  };
 
-  constructor() { }
+  constructor(private filteredTreeService: TreeFilterService) { }
 
   ngOnInit() {
+    this.updateModel();
+  }
+
+  async updateModel(): Promise<void> {
+    console.log('retrieving test file tree...');
+    this.model = await this.filteredTreeService.listTestFiles();
   }
 
 }

--- a/src/app/modules/test-navigator/test-navigator.module.ts
+++ b/src/app/modules/test-navigator/test-navigator.module.ts
@@ -1,10 +1,15 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TestNavigatorComponent } from './test-navigator.component';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { TreeViewerModule } from '@testeditor/testeditor-commons';
+import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule, TreeViewerModule
   ],
   declarations: [
     TestNavigatorComponent
@@ -13,4 +18,12 @@ import { TestNavigatorComponent } from './test-navigator.component';
     TestNavigatorComponent
   ]
 })
-export class TestNavigatorModule { }
+export class TestNavigatorModule {
+  static forRoot(persistenceConfig: PersistenceServiceConfig): ModuleWithProviders {
+    return {
+      ngModule: TestNavigatorModule,
+      providers: [PersistenceService, TreeFilterService, HttpProviderService,
+        { provide: PersistenceServiceConfig, useValue: persistenceConfig } ]
+    };
+  }
+}

--- a/src/app/modules/tree-filter-service/tree-filter.service.spec.ts
+++ b/src/app/modules/tree-filter-service/tree-filter.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { TreeFilterService } from './tree-filter.service';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
+import { MessagingModule } from '@testeditor/messaging-service';
+
+describe('TreeFilterService', () => {
+  const persistenceServiceConfig: PersistenceServiceConfig = { persistenceServiceUrl: 'http://example.org' };
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ MessagingModule.forRoot() ],
+      providers: [ TreeFilterService, HttpProviderService, PersistenceService,
+        { provide: PersistenceServiceConfig, useValue: persistenceServiceConfig } ]
+    });
+  });
+
+  it('should be created', inject([TreeFilterService], (service: TreeFilterService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/modules/tree-filter-service/tree-filter.service.ts
+++ b/src/app/modules/tree-filter-service/tree-filter.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { WorkspaceElement } from '../persistence-service/workspace-element';
+import { TestNavigatorTreeNode } from '../model/test-navigator-tree-node';
+
+@Injectable()
+export class TreeFilterService {
+
+  constructor(private persistenceService: PersistenceService) { }
+
+  async listTestFiles(): Promise<TestNavigatorTreeNode> {
+    return this.persistenceService.listFiles().then((root) => new TestNavigatorTreeNode(root));
+  }
+}

--- a/src/app/persistence.service.mock.ts
+++ b/src/app/persistence.service.mock.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { WorkspaceElement, ElementType } from './modules/persistence-service/workspace-element';
+import { AbstractPersistenceService } from './modules/persistence-service/persistence.service';
+import { Conflict } from './modules/persistence-service/conflict';
+
+@Injectable()
+export class PersistenceServiceMock extends AbstractPersistenceService {
+
+  readonly data: WorkspaceElement = {
+    name: 'root',
+    path: '',
+    type: ElementType.Folder,
+    children: [
+      {
+        name: 'hello.tsl',
+        path: 'hello.tsl',
+        type: ElementType.File,
+        children: []
+      },
+      {
+        name: 'world.tsl',
+        path: 'world.tsl',
+        type: ElementType.File,
+        children: []
+      },
+      {
+        name: 'com',
+        path: 'com',
+        type: ElementType.Folder,
+        children: [
+          {
+            name: 'example',
+            path: 'com/example',
+            type: ElementType.Folder,
+            children: [
+              {
+                name: 'test.tsl',
+                path: 'com/example/test.tsl',
+                type: ElementType.File,
+                children: []
+              },
+              {
+                name: 'test.tcl',
+                path: 'com/example/test.tcl',
+                type: ElementType.File,
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'test-editor.png',
+        path: 'test-editor.png',
+        type: ElementType.File,
+        children: []
+      }
+    ]
+  };
+
+  constructor(private http: HttpClient) {
+    super();
+  }
+
+  listFiles(): Promise<WorkspaceElement> {
+    return Promise.resolve(this.data);
+  }
+
+  createResource(path: string, type: string): Promise<string | Conflict> {
+    console.log(`Received createResource(path: '${path}', type: '${type}')`);
+    return Promise.reject('not supported by mock');
+  }
+
+  renameResource(newPath: string, oldPath: string): Promise<string | Conflict> {
+    console.log(`Received renameResource(newPath: '${newPath}', oldPath: '${oldPath}')`);
+    return Promise.reject('not supported by mock');
+  }
+
+  deleteResource(path: string): Promise<string> {
+    console.log(`Received deleteResource(path: '${path}')`);
+    return Promise.reject('not supported by mock');
+  }
+
+  getBinaryResource(path: string): Promise<Blob> {
+    console.log(`Received getResource(path: '${path}')`);
+    return this.http.get(this.getURL(path), { responseType: 'blob' }).toPromise();
+  }
+
+  getURL(path: string): string {
+    console.log(`Received getURL(path: '${path}')`);
+    // return the URL of an arbitrary image for the demo mock
+    return 'http://testeditor.org/wp-content/uploads/2014/05/05-narrow-de-300x187.png';
+  }
+
+}


### PR DESCRIPTION
* add `TreeViewer` dependency, use it in `TestNavigatorComponent` with (bare minimum to make it work)
* migrate and refactor `PersistenceService`, along with dependencies (data classes like `WorkspaceElement`)
* add an implementation of `TreeNode`, `TestNavigatorTreeNode`, that can be constructed from a `WorkspaceElement` (wraps around it)
* made provisions for a service that takes the result from the persistence service and returns the basic, filtered view we want in the test navigator instead (`TreeFilterService`, remains to be implemented, only translates from `WorkspaceElement` to `TestNavigatorTreeNode`)
* use `TestNavigatorComponent` in DemoApp