### PR TITLE
Feature/filter bar

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -20,6 +20,7 @@
       "prefix": "app",
       "styles": [
         "../node_modules/bootstrap/dist/css/bootstrap.min.css",
+        "../node_modules/font-awesome/css/font-awesome.min.css",
         "styles.css"
       ],
       "scripts": [],

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,14 +7,16 @@ import { PersistenceService } from './modules/persistence-service/persistence.se
 import { PersistenceServiceConfig } from './modules/persistence-service/persistence.service.config';
 import { TreeViewerModule } from '@testeditor/testeditor-commons';
 import { TreeFilterService } from './modules/tree-filter-service/tree-filter.service';
+import { FormsModule } from '@angular/forms';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { FilterBarComponent } from './modules/filter-bar/filter-bar.component';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     const persistenceServiceConfig: PersistenceServiceConfig = { persistenceServiceUrl: 'http://example.org' };
     TestBed.configureTestingModule({
-      imports: [ MessagingModule.forRoot(), TreeViewerModule ],
+      imports: [ MessagingModule.forRoot(), TreeViewerModule, FormsModule, ButtonsModule.forRoot() ],
       declarations: [
-        AppComponent,
-        TestNavigatorComponent
+        AppComponent, TestNavigatorComponent, FilterBarComponent
       ],
       providers: [ HttpProviderService, TreeFilterService, PersistenceService,
         { provide: PersistenceServiceConfig, useValue: persistenceServiceConfig } ]

--- a/src/app/modules/filter-bar/filter-bar.component.css
+++ b/src/app/modules/filter-bar/filter-bar.component.css
@@ -1,0 +1,19 @@
+.tsl {
+  color: lightgreen
+}
+
+.tcl {
+  color: lightblue
+}
+
+.aml {
+  color: lightcoral
+}
+
+#filter-bar {
+  display: flex;
+}
+
+#filter-bar > label {
+  flex-grow: 1;
+}

--- a/src/app/modules/filter-bar/filter-bar.component.html
+++ b/src/app/modules/filter-bar/filter-bar.component.html
@@ -1,0 +1,3 @@
+<p>
+  filter-bar works!
+</p>

--- a/src/app/modules/filter-bar/filter-bar.component.html
+++ b/src/app/modules/filter-bar/filter-bar.component.html
@@ -1,8 +1,8 @@
 <div id="filter-bar" class="btn-group">
   <label class="btn btn-dark" [(ngModel)]="filters.tsl"
-         btnCheckbox tabindex="0" role="button"><i class="fa fa-file tsl"></i></label>
+         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tsl"></i></label>
   <label class="btn btn-dark" [(ngModel)]="filters.tcl"
-         btnCheckbox tabindex="0" role="button"><i class="fa fa-file tcl"></i></label>
+         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tcl"></i></label>
   <label class="btn btn-dark" [(ngModel)]="filters.aml"
-         btnCheckbox tabindex="0" role="button"><i class="fa fa-file aml"></i></label>
+         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file aml"></i></label>
 </div>

--- a/src/app/modules/filter-bar/filter-bar.component.html
+++ b/src/app/modules/filter-bar/filter-bar.component.html
@@ -1,3 +1,8 @@
-<p>
-  filter-bar works!
-</p>
+<div id="filter-bar" class="btn-group">
+  <label class="btn btn-dark" [(ngModel)]="filters.tsl"
+         btnCheckbox tabindex="0" role="button"><i class="fa fa-file tsl"></i></label>
+  <label class="btn btn-dark" [(ngModel)]="filters.tcl"
+         btnCheckbox tabindex="0" role="button"><i class="fa fa-file tcl"></i></label>
+  <label class="btn btn-dark" [(ngModel)]="filters.aml"
+         btnCheckbox tabindex="0" role="button"><i class="fa fa-file aml"></i></label>
+</div>

--- a/src/app/modules/filter-bar/filter-bar.component.html
+++ b/src/app/modules/filter-bar/filter-bar.component.html
@@ -1,8 +1,8 @@
 <div id="filter-bar" class="btn-group">
-  <label class="btn btn-dark" [(ngModel)]="filters.tsl"
+  <label class="btn btn-dark" [(ngModel)]="filters.tsl" title="filter for specifications"
          btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tsl"></i></label>
-  <label class="btn btn-dark" [(ngModel)]="filters.tcl"
+  <label class="btn btn-dark" [(ngModel)]="filters.tcl" title="filter for tests"
          btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tcl"></i></label>
-  <label class="btn btn-dark" [(ngModel)]="filters.aml"
+  <label class="btn btn-dark" [(ngModel)]="filters.aml" title="filter for application mappings"
          btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file aml"></i></label>
 </div>

--- a/src/app/modules/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FilterBarComponent } from './filter-bar.component';
+
+describe('FilterBarComponent', () => {
+  let component: FilterBarComponent;
+  let fixture: ComponentFixture<FilterBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FilterBarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FilterBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.spec.ts
@@ -1,13 +1,15 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { FormsModule } from '@angular/forms';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { FilterBarComponent } from './filter-bar.component';
 
-describe('FilterBarComponent', () => {
+fdescribe('FilterBarComponent', () => {
   let component: FilterBarComponent;
   let fixture: ComponentFixture<FilterBarComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [ FormsModule, ButtonsModule.forRoot() ],
       declarations: [ FilterBarComponent ]
     })
     .compileComponents();

--- a/src/app/modules/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.spec.ts
@@ -22,7 +22,7 @@ class TestHostComponent {
 
 
 
-fdescribe('FilterBarComponent', () => {
+describe('FilterBarComponent', () => {
   let hostComponent: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 

--- a/src/app/modules/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.spec.ts
@@ -1,27 +1,61 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ViewChild } from '@angular/core';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
-import { FilterBarComponent } from './filter-bar.component';
+import { FilterBarComponent, FilterState } from './filter-bar.component';
+
+@Component({
+  selector: `app-host-component`,
+  template: `<app-filter-bar (filtersChanged)="onFiltersChanged($event)"></app-filter-bar>`
+})
+class TestHostComponent {
+  public filterState: FilterState;
+
+  @ViewChild(FilterBarComponent)
+  public filterBarUnderTest: FilterBarComponent;
+
+  onFiltersChanged(state: FilterState) {
+    this.filterState = state;
+  }
+}
+
+
 
 fdescribe('FilterBarComponent', () => {
-  let component: FilterBarComponent;
-  let fixture: ComponentFixture<FilterBarComponent>;
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ FormsModule, ButtonsModule.forRoot() ],
-      declarations: [ FilterBarComponent ]
+      declarations: [ TestHostComponent, FilterBarComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(FilterBarComponent);
-    component = fixture.componentInstance;
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(hostComponent.filterBarUnderTest).toBeTruthy();
   });
+
+  it('should fire an event passing on the filter state when a button is pressed', fakeAsync(() => {
+    // given
+    hostComponent.filterState = undefined;
+    const tslButton = fixture.debugElement.query(By.css('#filter-bar > label')).nativeElement;
+
+    // when
+    tslButton.click();
+    tick();
+
+    // then
+    expect(hostComponent.filterState.tsl).toBeTruthy();
+    expect(hostComponent.filterState.tcl).toBeFalsy();
+    expect(hostComponent.filterState.aml).toBeFalsy();
+  }));
 });

--- a/src/app/modules/filter-bar/filter-bar.component.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-filter-bar',
+  templateUrl: './filter-bar.component.html',
+  styleUrls: ['./filter-bar.component.css']
+})
+export class FilterBarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/modules/filter-bar/filter-bar.component.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.ts
@@ -6,6 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./filter-bar.component.css']
 })
 export class FilterBarComponent implements OnInit {
+  filters = { tsl: false, tcl: false, aml: false };
 
   constructor() { }
 

--- a/src/app/modules/filter-bar/filter-bar.component.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+
+export interface FilterState { tsl: boolean; tcl: boolean; aml: boolean; }
 
 @Component({
   selector: 'app-filter-bar',
@@ -6,11 +8,17 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./filter-bar.component.css']
 })
 export class FilterBarComponent implements OnInit {
-  filters = { tsl: false, tcl: false, aml: false };
+  filters: FilterState = { tsl: false, tcl: false, aml: false };
+
+  @Output() filtersChanged: EventEmitter<FilterState> = new EventEmitter<FilterState>();
 
   constructor() { }
 
   ngOnInit() {
+  }
+
+  onClick() {
+    this.filtersChanged.emit({tsl: this.filters.tsl, tcl: this.filters.tcl, aml: this.filters.aml});
   }
 
 }

--- a/src/app/modules/model/filters.spec.ts
+++ b/src/app/modules/model/filters.spec.ts
@@ -1,0 +1,84 @@
+import { FilterState } from '../filter-bar/filter-bar.component';
+import { TestNavigatorTreeNode} from '../model/test-navigator-tree-node';
+import { ElementType } from '../persistence-service/workspace-element';
+import { filterFor } from '../model/filters';
+import { filter } from 'rxjs/operator/filter';
+
+describe('filterFor', () => {
+
+  // 'state' test vector encoding:
+  // [<tsl filter on?>, <tcl filter on?>, <aml filter on?>, <file visible?>]
+
+
+  [[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [0, 1, 1, 0], [1, 0, 0, 1], [1, 0, 1, 1], [1, 1, 0, 1], [1, 1, 1, 1]].forEach((state) => {
+    it(`tsl files are ${state[3] ? 'shown' : 'hidden'} for filter state [${state.slice(0, 3)}]`, () => {
+      // given
+      const filterState: FilterState = { tsl: !!state[0], tcl: !!state[1], aml: !!state[2] };
+      const node = new TestNavigatorTreeNode({children: [], name: '', path: 'file.tsl', type: ElementType.File});
+
+      // when
+      const visible = filterFor(filterState, node);
+
+      // then
+      expect(visible).toEqual(!!state[3]);
+    });
+  });
+
+  [[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 1], [0, 1, 1, 1], [1, 0, 0, 0], [1, 0, 1, 0], [1, 1, 0, 1], [1, 1, 1, 1]].forEach((state) => {
+    ['tcl', 'tml', 'config'].forEach((extension) => {
+      it(`${extension} files are ${state[3] ? 'shown' : 'hidden'} for filter state [${state.slice(0, 3)}]`, () => {
+        // given
+        const filterState: FilterState = { tsl: !!state[0], tcl: !!state[1], aml: !!state[2] };
+        const node = new TestNavigatorTreeNode({children: [], name: '', path: `file.${extension}`, type: ElementType.File});
+
+        // when
+        const visible = filterFor(filterState, node);
+
+        // then
+        expect(visible).toEqual(!!state[3]);
+      });
+    });
+  });
+
+  [[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 0, 0], [0, 1, 1, 1], [1, 0, 0, 0], [1, 0, 1, 1], [1, 1, 0, 0], [1, 1, 1, 1]].forEach((state) => {
+    it(`aml files are ${state[3] ? 'shown' : 'hidden'} for filter state [${state.slice(0, 3)}]`, () => {
+      // given
+      const filterState: FilterState = { tsl: !!state[0], tcl: !!state[1], aml: !!state[2] };
+      const node = new TestNavigatorTreeNode({children: [], name: '', path: 'file.aml', type: ElementType.File});
+
+      // when
+      const visible = filterFor(filterState, node);
+
+      // then
+      expect(visible).toEqual(!!state[3]);
+    });
+  });
+
+  [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]].forEach((state) => {
+    it(`folders are always shown (also for filter state [${state.slice(0, 3)}])`, () => {
+      // given
+      const filterState: FilterState = { tsl: !!state[0], tcl: !!state[1], aml: !!state[2] };
+      const node = new TestNavigatorTreeNode({children: [], name: '', path: 'folder.aml', type: ElementType.Folder});
+
+      // when
+      const visible = filterFor(filterState, node);
+
+      // then
+      expect(visible).toBeTruthy();
+    });
+  });
+
+  [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]].forEach((state) => {
+    it(`files with unknown extensions are always hidden (also for filter state [${state.slice(0, 3)}])`, () => {
+      // given
+      const filterState: FilterState = { tsl: !!state[0], tcl: !!state[1], aml: !!state[2] };
+      const node = new TestNavigatorTreeNode({children: [], name: '', path: 'file.unknown', type: ElementType.File});
+
+      // when
+      const visible = filterFor(filterState, node);
+
+      // then
+      expect(visible).toBeFalsy();
+    });
+  });
+});

--- a/src/app/modules/model/filters.ts
+++ b/src/app/modules/model/filters.ts
@@ -1,6 +1,7 @@
 import { TreeNode } from '@testeditor/testeditor-commons';
 import { TestNavigatorTreeNode } from './test-navigator-tree-node';
 import { ElementType } from '../persistence-service/workspace-element';
+import { FilterState } from '../filter-bar/filter-bar.component';
 
   export type Filter = (node: TreeNode) => boolean;
 
@@ -15,6 +16,15 @@ import { ElementType } from '../persistence-service/workspace-element';
 
   export function isTestEditorFile(path: string) {
     return isTslFile(path) || isTclFile(path) || isConfigFile(path) || isTmlFile(path) || isAmlFile(path); }
+
+  export function filterFor(state: FilterState, node: TestNavigatorTreeNode): boolean {
+    return node.type === ElementType.Folder || (
+      ( !(state.tsl || state.tcl || state.aml) && isTestEditorFile(node.id)) ) || (
+      ( state.tsl && isTslFile(node.id) ) ||
+      ( state.tcl && (isTclFile(node.id) || isConfigFile(node.id) || isTmlFile(node.id)) ) ||
+      ( state.aml && isAmlFile(node.id) )
+    );
+  }
 
   export function isTslFile(path: string): boolean { return tslFileRegex.test(path); }
   export function isTclFile(path: string): boolean { return tclFileRegex.test(path); }

--- a/src/app/modules/test-navigator/test-navigator.component.html
+++ b/src/app/modules/test-navigator/test-navigator.component.html
@@ -13,5 +13,5 @@
   <div class="test-nav-tree">
     <app-tree-viewer [model]="model" [level]="0" [config]="treeConfig"></app-tree-viewer>
   </div>
-  <app-filter-bar></app-filter-bar>
+  <app-filter-bar (filtersChanged)="onFiltersChanged($event)"></app-filter-bar>
 </div>

--- a/src/app/modules/test-navigator/test-navigator.component.html
+++ b/src/app/modules/test-navigator/test-navigator.component.html
@@ -13,4 +13,5 @@
   <div class="test-nav-tree">
     <app-tree-viewer [model]="model" [level]="0" [config]="treeConfig"></app-tree-viewer>
   </div>
+  <app-filter-bar></app-filter-bar>
 </div>

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -1,23 +1,33 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TestNavigatorComponent } from './test-navigator.component';
-import { TreeViewerModule } from '@testeditor/testeditor-commons';
-import { PersistenceService } from '../persistence-service/persistence.service';
-import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
-import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { MessagingModule } from '@testeditor/messaging-service';
+import { TreeViewerModule } from '@testeditor/testeditor-commons';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { instance, mock, when } from 'ts-mockito/lib/ts-mockito';
+import { FilterBarComponent } from '../filter-bar/filter-bar.component';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { ElementType } from '../persistence-service/workspace-element';
 import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
+import { TestNavigatorComponent } from './test-navigator.component';
 
 describe('TestNavigatorComponent', () => {
   let component: TestNavigatorComponent;
   let fixture: ComponentFixture<TestNavigatorComponent>;
 
   beforeEach(async(() => {
-    const persistenceServiceConfig: PersistenceServiceConfig = { persistenceServiceUrl: 'http://example.org' };
+    const mockPersistenceService = mock(PersistenceService);
+    when(mockPersistenceService.listFiles()).thenResolve({
+      name: 'root', path: 'src/test/java', type: ElementType.Folder, children: [
+        {name: 'test.tcl', path: 'src/test/java/test.tcl', type: ElementType.File, children: []},
+        {name: 'test.tsl', path: 'src/test/java/test.tsl', type: ElementType.File, children: []}
+    ]});
     TestBed.configureTestingModule({
-      imports: [ TreeViewerModule, MessagingModule.forRoot() ],
-      declarations: [ TestNavigatorComponent ],
-      providers: [ HttpProviderService, TreeFilterService, PersistenceService,
-        { provide: PersistenceServiceConfig, useValue: persistenceServiceConfig } ]
+      imports: [ TreeViewerModule, MessagingModule.forRoot(), FormsModule, ButtonsModule.forRoot() ],
+      declarations: [ TestNavigatorComponent, FilterBarComponent ],
+      providers: [ HttpProviderService, TreeFilterService,
+        { provide: PersistenceService, useValue: instance(mockPersistenceService) } ]
     })
     .compileComponents();
   }));
@@ -30,5 +40,20 @@ describe('TestNavigatorComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('updates filter state on event from filter-bar child component', async () => {
+    // given
+    const tslFilterButton = fixture.debugElement.query(By.css('#filter-bar > label')).nativeElement;
+    await component.updateModel();
+    const tslFile = component.model.children[1]; expect(tslFile.name).toEqual('test.tsl');
+    const tclFile = component.model.children[0]; expect(tclFile.name).toEqual('test.tcl');
+
+    // when
+    tslFilterButton.click();
+
+    // then
+    expect(tslFile.cssClasses).not.toContain('hidden');
+    expect(tclFile.cssClasses).toContain('hidden');
   });
 });

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -1,12 +1,13 @@
 import { Component, isDevMode, OnDestroy, OnInit } from '@angular/core';
 import { MessagingService } from '@testeditor/messaging-service';
 import { TreeNode, TreeViewerConfig } from '@testeditor/testeditor-commons';
-import { testNavigatorFilter } from '../model/filters';
+import { testNavigatorFilter, filterFor } from '../model/filters';
 import { Subscription } from 'rxjs/Subscription';
 import { EDITOR_SAVE_COMPLETED } from '../event-types-in';
 import { WORKSPACE_RETRIEVED, WORKSPACE_RETRIEVED_FAILED } from '../event-types-out';
 import { TestNavigatorTreeNode } from '../model/test-navigator-tree-node';
 import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
+import { FilterState } from '../filter-bar/filter-bar.component';
 
 @Component({
   selector: 'app-test-navigator',
@@ -47,6 +48,10 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
         console.error('failed to load workspace');
       }
     }
+  }
+
+  onFiltersChanged(state: FilterState) {
+    this.model.forEach((node) => (node as TestNavigatorTreeNode).setVisible(filterFor(state, node)));
   }
 
 /**

--- a/src/app/modules/test-navigator/test-navigator.module.ts
+++ b/src/app/modules/test-navigator/test-navigator.module.ts
@@ -3,12 +3,12 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TreeViewerModule } from '@testeditor/testeditor-commons';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
-import { FilterBarComponent } from '../filter-bar/filter-bar/filter-bar.component';
 import { HttpProviderService } from '../http-provider-service/http-provider.service';
 import { PersistenceService } from '../persistence-service/persistence.service';
 import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
 import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
 import { TestNavigatorComponent } from './test-navigator.component';
+import { FilterBarComponent } from '../filter-bar/filter-bar.component';
 
 @NgModule({
   imports: [

--- a/src/app/modules/test-navigator/test-navigator.module.ts
+++ b/src/app/modules/test-navigator/test-navigator.module.ts
@@ -1,16 +1,18 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TestNavigatorComponent } from './test-navigator.component';
-import { PersistenceService } from '../persistence-service/persistence.service';
-import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
-import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TreeViewerModule } from '@testeditor/testeditor-commons';
-import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { FilterBarComponent } from '../filter-bar/filter-bar/filter-bar.component';
+import { HttpProviderService } from '../http-provider-service/http-provider.service';
+import { PersistenceService } from '../persistence-service/persistence.service';
+import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
+import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
+import { TestNavigatorComponent } from './test-navigator.component';
 
 @NgModule({
   imports: [
-    CommonModule, TreeViewerModule
+    CommonModule, TreeViewerModule, FormsModule, ButtonsModule.forRoot()
   ],
   declarations: [
     TestNavigatorComponent,

--- a/src/app/modules/test-navigator/test-navigator.module.ts
+++ b/src/app/modules/test-navigator/test-navigator.module.ts
@@ -6,13 +6,15 @@ import { TreeFilterService } from '../tree-filter-service/tree-filter.service';
 import { HttpProviderService } from '../http-provider-service/http-provider.service';
 import { TreeViewerModule } from '@testeditor/testeditor-commons';
 import { PersistenceServiceConfig } from '../persistence-service/persistence.service.config';
+import { FilterBarComponent } from '../filter-bar/filter-bar/filter-bar.component';
 
 @NgModule({
   imports: [
     CommonModule, TreeViewerModule
   ],
   declarations: [
-    TestNavigatorComponent
+    TestNavigatorComponent,
+    FilterBarComponent
   ],
   exports: [
     TestNavigatorComponent


### PR DESCRIPTION
adds a button bar below the tree view with three buttons:
* green file icon (show tsl files)
* blue file icon (show test files, i.e. tcl, tml, config)
* red file icon (show aml files)

only the files corresponding to the buttons that have been pressed are shown (multiple buttons can be pressed), unless *no* button is pressed, in which case all Test-Editor files are shown.

The stuff in the filter bar is hard-wired for now (i.e. it can't be configured in any way, it offers exactly those three buttons, in those colors, etc.)