### PR TITLE
use colored icons for TE files in tree view

### DIFF
--- a/src/app/modules/filter-bar/filter-bar.component.css
+++ b/src/app/modules/filter-bar/filter-bar.component.css
@@ -1,15 +1,3 @@
-.tsl {
-  color: lightgreen
-}
-
-.tcl {
-  color: lightblue
-}
-
-.aml {
-  color: lightcoral
-}
-
 #filter-bar {
   display: flex;
 }

--- a/src/app/modules/filter-bar/filter-bar.component.html
+++ b/src/app/modules/filter-bar/filter-bar.component.html
@@ -1,8 +1,8 @@
 <div id="filter-bar" class="btn-group">
   <label class="btn btn-dark" [(ngModel)]="filters.tsl" title="filter for specifications"
-         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tsl"></i></label>
+         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tsl-file-color"></i></label>
   <label class="btn btn-dark" [(ngModel)]="filters.tcl" title="filter for tests"
-         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tcl"></i></label>
+         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tcl-file-color"></i></label>
   <label class="btn btn-dark" [(ngModel)]="filters.aml" title="filter for application mappings"
-         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file aml"></i></label>
+         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file aml-file-color"></i></label>
 </div>

--- a/src/app/modules/model/test-navigator-tree-node.ts
+++ b/src/app/modules/model/test-navigator-tree-node.ts
@@ -6,8 +6,10 @@ export class TestNavigatorTreeNode implements TreeNode {
   private static readonly folderCssClass = 'fas fa-folder';
   private static readonly unknownFileCssClass = 'fas fa-question';
   private static readonly extensionToCssClass = {
-    'bmp': 'fas fas fa-image', 'png': 'fas fa-image', 'jpg': 'fas fa-image', 'jpeg': 'fas fa-image', 'gif': 'fas fa-image',
-    'svg': 'fas fa-image', 'tsl': 'fas fa-file', 'tcl': 'fas fa-file', 'tml': 'fas fa-file', 'config': 'fas fa-file', 'aml': 'fas fa-file'};
+    'bmp': 'fas fas fa-image', 'png': 'fas fa-image', 'jpg': 'fas fa-image',
+    'jpeg': 'fas fa-image', 'gif': 'fas fa-image', 'svg': 'fas fa-image',
+    'tsl': 'fas fa-file tsl-file-color', 'tcl': 'fas fa-file tcl-file-color', 'tml': 'fas fa-file tcl-file-color',
+    'config': 'fas fa-file tcl-file-color', 'aml': 'fas fa-file aml-file-color'};
 
   private _children: TestNavigatorTreeNode[];
   collapsedCssClasses = 'fas fa-chevron-right';

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
+.tsl-file-color { color: lightgreen }
+.tcl-file-color { color: lightblue }
+.aml-file-color { color: lightcoral }


### PR DESCRIPTION
defines and uses three css classes for tree view element icons, for which the surrounding project (`test-editor-web`) needs to provide stylings for them to have any effect. Defining them inside this project would either require to duplicate the information (for the filter bar and the tree view), or pierce the css scopes with something like `::ng-deep`…

The colors defined here (`styles.css`) only apply for the demo app.