### PR TITLE
Fix/root node

### DIFF
--- a/src/app/modules/model/test-navigator-tree-node.ts
+++ b/src/app/modules/model/test-navigator-tree-node.ts
@@ -52,6 +52,10 @@ export class TestNavigatorTreeNode implements TreeNode {
     return this.workspaceElement.name;
   }
 
+  set name(displayName: string) {
+    this.workspaceElement.name = displayName;
+  }
+
   get type(): ElementType {
     return this.workspaceElement.type;
   }

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -223,6 +223,20 @@ describe('TestNavigatorComponent', () => {
     expect().nothing();
   });
 
+  it('disables rename button when root element is selected', async () => {
+    // given
+    await component.updateModel();
+    fixture.detectChanges();
+    const renameButton = fixture.debugElement.query(By.css('#rename'));
+    const root = fixture.debugElement.query(By.css('.tree-view-item-key'));
+
+    // when
+    root.nativeElement.click(); fixture.detectChanges();
+
+    // then
+    expect(renameButton.nativeElement.disabled).toBeTruthy();
+  });
+
   it('disables rename button when selection is dirty', async () => {
     // given
     await component.updateModel();

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -291,7 +291,7 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
   }
 
   get renameDisabled(): boolean {
-    return !this.selectedNode || this.selectedNode.dirty;
+    return !this.selectedNode || this.selectedNode.dirty || this.selectedNode === this.selectedNode.root;
   }
 
   get renameHoverText(): string {
@@ -299,6 +299,8 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
     if (this.selectedNode) {
       if (this.selectedNode.dirty) {
         result = `cannot rename "${this.selectedNode.name}": unsaved changes`;
+      } else if (this.selectedNode === this.selectedNode.root) {
+        result = 'cannot rename the root element';
       } else {
         result = `rename "${this.selectedNode.name}`;
       }

--- a/src/app/modules/tree-filter-service/tree-filter.service.spec.ts
+++ b/src/app/modules/tree-filter-service/tree-filter.service.spec.ts
@@ -76,4 +76,16 @@ describe('TreeFilterService', () => {
 
   }));
 
+  it('should set the display name of the root to "workspace"', inject([TreeFilterService], async (service: TreeFilterService) => {
+    // given
+    when(mockPersistenceService.listFiles()).thenResolve(sampleWorkspace);
+
+    // when
+    const actualTestFile = await service.listTreeNodes();
+
+    // then
+    expect(actualTestFile.id).toEqual('src/test/java');
+    expect(actualTestFile.name).toEqual('Workspace');
+  }));
+
 });

--- a/src/app/modules/tree-filter-service/tree-filter.service.ts
+++ b/src/app/modules/tree-filter-service/tree-filter.service.ts
@@ -12,7 +12,10 @@ export class TreeFilterService {
   async listTreeNodes(): Promise<TestNavigatorTreeNode> {
     return this.persistenceService.listFiles().then(
       (root) => {
-        return new TestNavigatorTreeNode(this.findFirst(root, (element) => element.path === TreeFilterService.ROOT_PATH));
+        const testNavigatorRoot = new TestNavigatorTreeNode(
+          this.findFirst(root, (element) => element.path === TreeFilterService.ROOT_PATH));
+        testNavigatorRoot.name = 'Workspace';
+        return testNavigatorRoot;
       });
   }
 

--- a/src/app/modules/tree-filter-service/tree-filter.service.ts
+++ b/src/app/modules/tree-filter-service/tree-filter.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { TestNavigatorTreeNode } from '../model/test-navigator-tree-node';
 import { PersistenceService } from '../persistence-service/persistence.service';
+import { WorkspaceElement } from '../persistence-service/workspace-element';
 
 @Injectable()
 export class TreeFilterService {
@@ -11,10 +12,23 @@ export class TreeFilterService {
   async listTreeNodes(): Promise<TestNavigatorTreeNode> {
     return this.persistenceService.listFiles().then(
       (root) => {
-        const testNavigatorRoot = new TestNavigatorTreeNode(root);
-        return testNavigatorRoot.findFirst((node) => (node as TestNavigatorTreeNode).id === TreeFilterService.ROOT_PATH);
+        return new TestNavigatorTreeNode(this.findFirst(root, (element) => element.path === TreeFilterService.ROOT_PATH));
       });
   }
 
+  private findFirst(root: WorkspaceElement, condition: (element: WorkspaceElement) => boolean): WorkspaceElement {
+    let result: WorkspaceElement = null;
+    if (condition(root)) {
+      result = root;
+    } else {
+      for (const child of root.children) {
+        result = this.findFirst(child, condition);
+        if (result !== null) {
+          break;
+        }
+      }
+    }
+    return result;
+  }
 
 }


### PR DESCRIPTION
* disable rename button for root
* set display name of root node to "workspace"
* fix derivation of root node overshooting the visible root, and going all the way back to the original root (of the full workspace as provided by the backend).