### PR TITLE
show validation markers on filter buttons for filtered-out files

### DIFF
--- a/src/app/modules/filter-bar/filter-bar.component.css
+++ b/src/app/modules/filter-bar/filter-bar.component.css
@@ -5,3 +5,9 @@
 #filter-bar > label {
   flex-grow: 1;
 }
+
+.validation-marker {
+  font-size: .8em;
+  margin-top: 25%;
+  margin-left: 25%
+}

--- a/src/app/modules/filter-bar/filter-bar.component.html
+++ b/src/app/modules/filter-bar/filter-bar.component.html
@@ -1,8 +1,38 @@
 <div id="filter-bar" class="btn-group">
-  <label class="btn btn-dark" [(ngModel)]="filters.tsl" title="filter for specifications"
-         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tsl-file-color"></i></label>
-  <label class="btn btn-dark" [(ngModel)]="filters.tcl" title="filter for tests"
-         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file tcl-file-color"></i></label>
-  <label class="btn btn-dark" [(ngModel)]="filters.aml" title="filter for application mappings"
-         btnCheckbox tabindex="0" role="button" (click)="onClick()"><i class="fa fa-file aml-file-color"></i></label>
+  <label id="filter-tsl" class="btn btn-dark" [(ngModel)]="filters.tsl" title="filter for specifications"
+         btnCheckbox tabindex="0" role="button" (click)="onClick()">
+    <span class="fa-stack">
+      <i class="fa fa-file fa-stack-1x tsl-file-color"></i>
+      <i class="fa fa-stack-1x validation-marker"
+         [ngClass]="{
+           'fa-exclamation-circle validation-errors': showValidationMarkers('tsl', 'errors'),
+           'fa-exclamation-triangle validation-warnings': showValidationMarkers('tsl', 'warnings'),
+           'fa-info-circle validation-infos': showValidationMarkers('tsl', 'infos')
+          }"></i>
+    </span>
+  </label>
+  <label id="filter-tcl" class="btn btn-dark" [(ngModel)]="filters.tcl" title="filter for tests"
+         btnCheckbox tabindex="0" role="button" (click)="onClick()">
+    <span class="fa-stack">
+        <i class="fa fa-file tcl-file-color"></i>
+        <i class="fa fa-stack-1x validation-marker"
+        [ngClass]="{
+          'fa-exclamation-circle validation-errors': showValidationMarkers('tcl', 'errors'),
+          'fa-exclamation-triangle validation-warnings': showValidationMarkers('tcl', 'warnings'),
+          'fa-info-circle validation-infos': showValidationMarkers('tcl', 'infos')
+         }"></i>
+    </span>
+  </label>
+  <label id="filter-aml" class="btn btn-dark" [(ngModel)]="filters.aml" title="filter for application mappings"
+         btnCheckbox tabindex="0" role="button" (click)="onClick()">
+    <span class="fa-stack">
+        <i class="fa fa-file aml-file-color"></i>
+        <i class="fa fa-stack-1x validation-marker"
+        [ngClass]="{
+          'fa-exclamation-circle validation-errors': showValidationMarkers('aml', 'errors'),
+          'fa-exclamation-triangle validation-warnings': showValidationMarkers('aml', 'warnings'),
+          'fa-info-circle validation-infos': showValidationMarkers('aml', 'infos')
+         }"></i>
+    </span>
+  </label>
 </div>

--- a/src/app/modules/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.spec.ts
@@ -3,17 +3,30 @@ import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
-import { FilterBarComponent, FilterState } from './filter-bar.component';
+import { FilterBarComponent, FilterState, FilterType } from './filter-bar.component';
+import { ValidationMarkerSummary } from '../validation-marker-summary/validation-marker-summary';
 
 @Component({
   selector: `app-host-component`,
-  template: `<app-filter-bar (filtersChanged)="onFiltersChanged($event)"></app-filter-bar>`
+  template: `<app-filter-bar [getFilteredOutMarkers]="getFilteredOutMarkers" (filtersChanged)="onFiltersChanged($event)"></app-filter-bar>`
 })
 class TestHostComponent {
+  private static markers = { tsl: new ValidationMarkerSummary({errors: 1, warnings: 2, infos: 3}),
+                             tcl: new ValidationMarkerSummary({errors: 0, warnings: 1, infos: 2}),
+                             aml: new ValidationMarkerSummary({errors: 0, warnings: 0, infos: 1})};
+
   public filterState: FilterState;
 
   @ViewChild(FilterBarComponent)
   public filterBarUnderTest: FilterBarComponent;
+
+  getFilteredOutMarkers = (type: FilterType) => {
+    if (this.filterState && !this.filterState[type] && (this.filterState.aml || this.filterState.tsl || this.filterState.tcl)) {
+      return TestHostComponent.markers[type];
+    } else {
+      return ValidationMarkerSummary.zero;
+    }
+  }
 
   onFiltersChanged(state: FilterState) {
     this.filterState = state;
@@ -58,4 +71,93 @@ describe('FilterBarComponent', () => {
     expect(hostComponent.filterState.tcl).toBeFalsy();
     expect(hostComponent.filterState.aml).toBeFalsy();
   }));
+
+  ['tcl', 'tsl', 'aml'].forEach((type: 'tcl' | 'tsl' | 'aml') =>
+  it(`never shows ${type} validation markers when ${type} files are not being filtered out`, fakeAsync(() => {
+    // given
+    hostComponent.filterState = { tsl: true, tcl: true, aml: true };
+
+    // when
+    const actual = hostComponent.filterBarUnderTest.showValidationMarkers(type, 'errors');
+
+    // then
+    expect(actual).toBeFalsy();
+  })));
+
+  it(`shows markers on types that have been filtered out`, fakeAsync(() => {
+    // given
+    hostComponent.filterState = { tsl: true, tcl: false, aml: false };
+    const tslButton = fixture.debugElement.query(By.css('#filter-bar > label')).nativeElement;
+
+    // when
+    tslButton.click();
+    tick();
+
+    // then
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('tsl', 'errors')).toBeFalsy('tsl files must not show error markers');
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('tsl', 'warnings')).toBeFalsy('tsl files must not show warning markers');
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('tsl', 'infos')).toBeFalsy('tsl files must not show info markers');
+
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('tcl', 'errors')).toBeFalsy('tcl files must not show error markers');
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('tcl', 'warnings')).toBeTruthy('tcl files should show warning markers');
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('tcl', 'infos')).toBeFalsy('tcl files must not show error markers');
+
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('aml', 'errors')).toBeFalsy('aml files must not show error markers');
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('aml', 'warnings')).toBeFalsy('aml files must not show warning markers');
+    expect(hostComponent.filterBarUnderTest.showValidationMarkers('aml', 'infos')).toBeTruthy('aml files should show info markers');
+  }));
+
+  it('sets the right css classes to display error markers on types that have been filtered out', () => {
+    // given
+    hostComponent.filterState = { tsl: false, tcl: true, aml: true };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    const markerIcon = fixture.debugElement.query(By.css('#filter-tsl .validation-marker'));
+    expect(markerIcon.classes['fa-exclamation-circle']).toBeTruthy();
+    expect(markerIcon.classes['validation-errors']).toBeTruthy();
+
+    expect(markerIcon.classes['fa-exclamation-triangle']).toBeFalsy();
+    expect(markerIcon.classes['validation-warnings']).toBeFalsy();
+    expect(markerIcon.classes['fa-info-circle']).toBeFalsy();
+    expect(markerIcon.classes['validation-infos']).toBeFalsy();
+  });
+
+  it('sets the right css classes to display warning markers on types that have been filtered out', () => {
+    // given
+    hostComponent.filterState = { tsl: true, tcl: false, aml: true };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    const markerIcon = fixture.debugElement.query(By.css('#filter-tcl .validation-marker'));
+    expect(markerIcon.classes['fa-exclamation-triangle']).toBeTruthy();
+    expect(markerIcon.classes['validation-warnings']).toBeTruthy();
+
+    expect(markerIcon.classes['fa-exclamation-circle']).toBeFalsy();
+    expect(markerIcon.classes['validation-errors']).toBeFalsy();
+    expect(markerIcon.classes['fa-info-circle']).toBeFalsy();
+    expect(markerIcon.classes['validation-infos']).toBeFalsy();
+  });
+
+  it('sets the right css classes to display info markers on types that have been filtered out', () => {
+    // given
+    hostComponent.filterState = { tsl: true, tcl: true, aml: false };
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    const markerIcon = fixture.debugElement.query(By.css('#filter-aml .validation-marker'));
+    expect(markerIcon.classes['fa-info-circle']).toBeTruthy();
+    expect(markerIcon.classes['validation-infos']).toBeTruthy();
+
+    expect(markerIcon.classes['fa-exclamation-circle']).toBeFalsy();
+    expect(markerIcon.classes['validation-errors']).toBeFalsy();
+    expect(markerIcon.classes['fa-exclamation-triangle']).toBeFalsy();
+    expect(markerIcon.classes['validation-warnings']).toBeFalsy();
+  });
 });

--- a/src/app/modules/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.spec.ts
@@ -72,10 +72,10 @@ describe('FilterBarComponent', () => {
     expect(hostComponent.filterState.aml).toBeFalsy();
   }));
 
-  ['tcl', 'tsl', 'aml'].forEach((type: 'tcl' | 'tsl' | 'aml') =>
+  ['tcl', 'tsl', 'aml'].forEach((type: FilterType) =>
   it(`never shows ${type} validation markers when ${type} files are not being filtered out`, fakeAsync(() => {
     // given
-    hostComponent.filterState = { tsl: true, tcl: true, aml: true };
+    hostComponent.getFilteredOutMarkers = () => ValidationMarkerSummary.zero;
 
     // when
     const actual = hostComponent.filterBarUnderTest.showValidationMarkers(type, 'errors');

--- a/src/app/modules/filter-bar/filter-bar.component.ts
+++ b/src/app/modules/filter-bar/filter-bar.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
+import { ValidationMarkerSummary } from '../validation-marker-summary/validation-marker-summary';
 
 export interface FilterState { tsl: boolean; tcl: boolean; aml: boolean; }
+export type FilterType = 'tsl' | 'tcl' | 'aml';
 
 @Component({
   selector: 'app-filter-bar',
@@ -9,7 +11,7 @@ export interface FilterState { tsl: boolean; tcl: boolean; aml: boolean; }
 })
 export class FilterBarComponent implements OnInit {
   filters: FilterState = { tsl: false, tcl: false, aml: false };
-
+  @Input() getFilteredOutMarkers: (type: FilterType) => ValidationMarkerSummary;
   @Output() filtersChanged: EventEmitter<FilterState> = new EventEmitter<FilterState>();
 
   constructor() { }
@@ -19,6 +21,15 @@ export class FilterBarComponent implements OnInit {
 
   onClick() {
     this.filtersChanged.emit({tsl: this.filters.tsl, tcl: this.filters.tcl, aml: this.filters.aml});
+  }
+
+  showValidationMarkers(type: FilterType, severity: 'errors' | 'warnings' | 'infos'): boolean {
+    const markers = this.getFilteredOutMarkers(type);
+    switch (severity) {
+      case 'infos': return markers.errors <= 0 && markers.warnings <= 0 && markers.infos > 0;
+      case 'warnings': return markers.errors <= 0 && markers.warnings > 0;
+      case 'errors': return markers.errors > 0;
+    }
   }
 
 }

--- a/src/app/modules/model/filters.ts
+++ b/src/app/modules/model/filters.ts
@@ -1,7 +1,7 @@
 import { TreeNode } from '@testeditor/testeditor-commons';
 import { TestNavigatorTreeNode } from './test-navigator-tree-node';
 import { ElementType } from '../persistence-service/workspace-element';
-import { FilterState } from '../filter-bar/filter-bar.component';
+import { FilterState, FilterType } from '../filter-bar/filter-bar.component';
 
   export type Filter = (node: TreeNode) => boolean;
 
@@ -24,6 +24,14 @@ import { FilterState } from '../filter-bar/filter-bar.component';
       ( state.tcl && (isTclFile(node.id) || isConfigFile(node.id) || isTmlFile(node.id)) ) ||
       ( state.aml && isAmlFile(node.id) )
     );
+  }
+
+  export function isFileOfType(path: string, type: FilterType): boolean {
+    switch (type) {
+      case 'tsl': return isTslFile(path);
+      case 'tcl': return isTclFile(path) || isConfigFile(path) || isTmlFile(path);
+      case 'aml': return isAmlFile(path);
+    }
   }
 
   export function isTslFile(path: string): boolean { return tslFileRegex.test(path); }

--- a/src/app/modules/test-navigator/test-navigator.component.html
+++ b/src/app/modules/test-navigator/test-navigator.component.html
@@ -20,5 +20,5 @@
   </div>
   <div *ngIf="errorMessage" id="errorMessage" class="alert alert-danger">{{errorMessage}}</div>
   <div *ngIf="notification" id="notification" class="alert alert-info">{{notification}}</div>
-  <app-filter-bar (filtersChanged)="onFiltersChanged($event)"></app-filter-bar>
+  <app-filter-bar [getFilteredOutMarkers]="getFilteredOutMarkers" (filtersChanged)="onFiltersChanged($event)"></app-filter-bar>
 </div>

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -5,7 +5,6 @@ import { MessagingModule, MessagingService } from '@testeditor/messaging-service
 import { IndicatorFieldSetup, TreeViewerModule } from '@testeditor/testeditor-commons';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { instance, mock, when, verify, anyString, anything } from 'ts-mockito/lib/ts-mockito';
-import { TEST_EXECUTION_STARTED, TEST_EXECUTION_START_FAILED } from '../event-types-in';
 import { FilterBarComponent } from '../filter-bar/filter-bar.component';
 import { HttpProviderService } from '../http-provider-service/http-provider.service';
 import { IndexService } from '../index-service/index.service';

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -69,10 +69,14 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
   /* get markers that are not visible in the test navigator, since affected files are filtered by the current FilterState */
   getFilteredOutMarkers = (type: FilterType) => {
     let markers = ValidationMarkerSummary.zero;
-    if (this.filterState && !this.filterState[type] && (this.filterState.aml || this.filterState.tsl || this.filterState.tcl)) {
+    if (this.filterState && !this.filterState[type] && this.hasActiveFilter) {
       this.model.forEach((node) => isFileOfType(node.id, type) ? markers = markers.add(node.validation) : {});
     }
     return markers;
+  }
+
+  private get hasActiveFilter(): boolean {
+    return this.filterState.aml || this.filterState.tsl || this.filterState.tcl;
   }
 
   constructor(private filteredTreeService: TreeFilterService,

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -66,6 +66,7 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
     indicatorFields: []
   };
 
+  /* get markers that are not visible in the test navigator, since affected files are filtered by the current FilterState */
   getFilteredOutMarkers = (type: FilterType) => {
     let markers = ValidationMarkerSummary.zero;
     if (this.filterState && !this.filterState[type] && (this.filterState.aml || this.filterState.tsl || this.filterState.tcl)) {

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -69,14 +69,14 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
   /* get markers that are not visible in the test navigator, since affected files are filtered by the current FilterState */
   getFilteredOutMarkers = (type: FilterType) => {
     let markers = ValidationMarkerSummary.zero;
-    if (this.filterState && !this.filterState[type] && this.hasActiveFilter) {
+    if (this.hasActiveFilter && !this.filterState[type]) {
       this.model.forEach((node) => isFileOfType(node.id, type) ? markers = markers.add(node.validation) : {});
     }
     return markers;
   }
 
   private get hasActiveFilter(): boolean {
-    return this.filterState.aml || this.filterState.tsl || this.filterState.tcl;
+    return this.filterState && (this.filterState.aml || this.filterState.tsl || this.filterState.tcl);
   }
 
   constructor(private filteredTreeService: TreeFilterService,

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -7,9 +7,9 @@ import { Subscription } from 'rxjs/Subscription';
 import { EDITOR_DIRTY_CHANGED, EDITOR_SAVE_COMPLETED  } from '../event-types-in';
 import { NAVIGATION_CREATED, NAVIGATION_OPEN, NAVIGATION_RENAMED, NAVIGATION_DELETED,
          WORKSPACE_RETRIEVED, WORKSPACE_RETRIEVED_FAILED, SNACKBAR_DISPLAY_NOTIFICATION, TEST_SELECTED } from '../event-types-out';
-import { FilterState } from '../filter-bar/filter-bar.component';
+import { FilterState, FilterType } from '../filter-bar/filter-bar.component';
 import { IndexService } from '../index-service/index.service';
-import { filterFor, testNavigatorFilter } from '../model/filters';
+import { filterFor, testNavigatorFilter, isFileOfType } from '../model/filters';
 import { TestNavigatorTreeNode } from '../model/test-navigator-tree-node';
 import { isConflict, Conflict } from '../persistence-service/conflict';
 import { PersistenceService } from '../persistence-service/persistence.service';
@@ -65,6 +65,14 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
       new DeleteAction(node, (_node: TestNavigatorTreeNode) => this.onDeleteConfirm(_node))),
     indicatorFields: []
   };
+
+  getFilteredOutMarkers = (type: FilterType) => {
+    let markers = ValidationMarkerSummary.zero;
+    if (this.filterState && !this.filterState[type] && (this.filterState.aml || this.filterState.tsl || this.filterState.tcl)) {
+      this.model.forEach((node) => isFileOfType(node.id, type) ? markers = markers.add(node.validation) : {});
+    }
+    return markers;
+  }
 
   constructor(private filteredTreeService: TreeFilterService,
               private messagingService: MessagingService,


### PR DESCRIPTION
One thing that is still missing from this PR is displaying tooltip summaries for the validation markers (i.e. "1 error(s), 2 warning(s), 3 info(s)"). I need to refactor a bit so that the tree isn't traversed every time Angular tries to re-render parts of the DOM and checks whether to display marker icons and tooltip texts…