### PR TITLE
Feature/phantom node activity

### DIFF
--- a/src/app/modules/model/test-navigator-tree-node.ts
+++ b/src/app/modules/model/test-navigator-tree-node.ts
@@ -93,13 +93,14 @@ export class TestNavigatorTreeNode implements TreeNode {
   }
 
   set activities(value: UserActivitySet) {
-      this.updateParentActivities(this.id, value);
+    this._activities.clear();
+    this.setDescendantActivity(this.id, value);
   }
 
-  private updateParentActivities(element: string, uaSet: UserActivitySet) {
+  setDescendantActivity(element: string, uaSet: UserActivitySet): any {
     this._activities.set(element, uaSet);
     if (this.parent && !this.isFiltered()) {
-      this.parent.updateParentActivities(element, uaSet);
+      this.parent.setDescendantActivity(element, uaSet);
     }
   }
 

--- a/src/app/modules/model/test-navigator-tree-node.ts
+++ b/src/app/modules/model/test-navigator-tree-node.ts
@@ -94,13 +94,13 @@ export class TestNavigatorTreeNode implements TreeNode {
 
   set activities(value: UserActivitySet) {
     this._activities.clear();
-    this.setDescendantActivity(this.id, value);
+    this.setAncestorsAcitivties(this.id, value);
   }
 
-  setDescendantActivity(element: string, uaSet: UserActivitySet): any {
-    this._activities.set(element, uaSet);
+  setAncestorsAcitivties(elementKey: string, uaSet: UserActivitySet): void {
+    this._activities.set(elementKey, uaSet);
     if (this.parent && !this.isFiltered()) {
-      this.parent.setDescendantActivity(element, uaSet);
+      this.parent.setAncestorsAcitivties(elementKey, uaSet);
     }
   }
 
@@ -142,6 +142,14 @@ export class TestNavigatorTreeNode implements TreeNode {
 
     }
     return this._children;
+  }
+
+  hasChild(id: string): boolean {
+    return this.children && this.children.some((child) => child.id === id);
+  }
+
+  isAncestorOf(id: string): boolean {
+    return id.startsWith(this.id);
   }
 
   addChild(rawElement: WorkspaceElement): TestNavigatorTreeNode {

--- a/src/app/modules/test-navigator/test-navigator-field-setup.ts
+++ b/src/app/modules/test-navigator/test-navigator-field-setup.ts
@@ -32,12 +32,13 @@ export class TestNavigatorFieldSetup implements IndicatorFieldSetup {
   private readonly activityMarkerSetup: Field;
 
   private readonly mixedActivityMarkerState: MarkerState = {
-    condition: (node: TestNavigatorTreeNode) => node.activities.filterVisibleCloserAncestors(node).getTypes().length > 1,
+    condition: (node: TestNavigatorTreeNode) => node.activities
+      .ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getTypes().length > 1,
     cssClasses: this.userActivityStyles.getDefaultCssClasses(),
     label: (node: TestNavigatorTreeNode) =>
-      node.activities.filterVisibleCloserAncestors(node).getTypes().map((userActivity) =>
+      node.activities.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getTypes().map((userActivity) =>
         this.userActivityLabeler.getLabel({
-          users: node.activities.filterVisibleCloserAncestors(node).getUsers(userActivity),
+          users: node.activities.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getUsers(userActivity),
           activityType: userActivity,
           forChildElement: node.type === ElementType.Folder
         })
@@ -63,10 +64,11 @@ export class TestNavigatorFieldSetup implements IndicatorFieldSetup {
 
   private singleActivityMarkerStates(userActivityList: string[]): MarkerState[] {
     return userActivityList.map((userActivity) => ({
-      condition: (node: TestNavigatorTreeNode) => node.activities.filterVisibleCloserAncestors(node).hasOnly(userActivity),
+      condition: (node: TestNavigatorTreeNode) => node.activities
+        .ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).hasOnly(userActivity),
       cssClasses: this.userActivityStyles.getCssClasses(userActivity),
       label: (node: TestNavigatorTreeNode) => this.userActivityLabeler.getLabel({
-        users: node.activities.filterVisibleCloserAncestors(node).getUsers(userActivity),
+        users: node.activities.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getUsers(userActivity),
         activityType: userActivity,
         forChildElement: node.type === ElementType.Folder
       })

--- a/src/app/modules/test-navigator/test-navigator-field-setup.ts
+++ b/src/app/modules/test-navigator/test-navigator-field-setup.ts
@@ -32,12 +32,12 @@ export class TestNavigatorFieldSetup implements IndicatorFieldSetup {
   private readonly activityMarkerSetup: Field;
 
   private readonly mixedActivityMarkerState: MarkerState = {
-    condition: (node: TestNavigatorTreeNode) => node.activities.getTypes(this.showOwnOrAll(node)).length > 1,
+    condition: (node: TestNavigatorTreeNode) => node.activities.filterVisibleCloserAncestors(node).getTypes().length > 1,
     cssClasses: this.userActivityStyles.getDefaultCssClasses(),
     label: (node: TestNavigatorTreeNode) =>
-      node.activities.getTypes(this.showOwnOrAll(node)).map((userActivity) =>
+      node.activities.filterVisibleCloserAncestors(node).getTypes().map((userActivity) =>
         this.userActivityLabeler.getLabel({
-          users: node.activities.getUsers(userActivity, this.showOwnOrAll(node)),
+          users: node.activities.filterVisibleCloserAncestors(node).getUsers(userActivity),
           activityType: userActivity,
           forChildElement: node.type === ElementType.Folder
         })
@@ -63,23 +63,14 @@ export class TestNavigatorFieldSetup implements IndicatorFieldSetup {
 
   private singleActivityMarkerStates(userActivityList: string[]): MarkerState[] {
     return userActivityList.map((userActivity) => ({
-      condition: (node: TestNavigatorTreeNode) => node.activities.hasOnly(userActivity, this.showOwnOrAll(node)),
+      condition: (node: TestNavigatorTreeNode) => node.activities.filterVisibleCloserAncestors(node).hasOnly(userActivity),
       cssClasses: this.userActivityStyles.getCssClasses(userActivity),
       label: (node: TestNavigatorTreeNode) => this.userActivityLabeler.getLabel({
-        users: node.activities.getUsers(userActivity, this.showOwnOrAll(node)),
+        users: node.activities.filterVisibleCloserAncestors(node).getUsers(userActivity),
         activityType: userActivity,
         forChildElement: node.type === ElementType.Folder
       })
     }));
-  }
-
-
-  private showOwnOrAll(node: TestNavigatorTreeNode): string {
-    if (node.type === ElementType.Folder && node.expanded) {
-      return node.id;
-    } else {
-      return undefined;
-    }
   }
 
 }

--- a/src/app/modules/test-navigator/test-navigator-field-setup.ts
+++ b/src/app/modules/test-navigator/test-navigator-field-setup.ts
@@ -33,12 +33,12 @@ export class TestNavigatorFieldSetup implements IndicatorFieldSetup {
 
   private readonly mixedActivityMarkerState: MarkerState = {
     condition: (node: TestNavigatorTreeNode) => node.activities
-      .ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getTypes().length > 1,
+      .withoutBetterFittingNodeForDisplay(node).getTypes().length > 1,
     cssClasses: this.userActivityStyles.getDefaultCssClasses(),
     label: (node: TestNavigatorTreeNode) =>
-      node.activities.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getTypes().map((userActivity) =>
+      node.activities.withoutBetterFittingNodeForDisplay(node).getTypes().map((userActivity) =>
         this.userActivityLabeler.getLabel({
-          users: node.activities.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getUsers(userActivity),
+          users: node.activities.withoutBetterFittingNodeForDisplay(node).getUsers(userActivity),
           activityType: userActivity,
           forChildElement: node.type === ElementType.Folder
         })
@@ -65,10 +65,10 @@ export class TestNavigatorFieldSetup implements IndicatorFieldSetup {
   private singleActivityMarkerStates(userActivityList: string[]): MarkerState[] {
     return userActivityList.map((userActivity) => ({
       condition: (node: TestNavigatorTreeNode) => node.activities
-        .ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).hasOnly(userActivity),
+        .withoutBetterFittingNodeForDisplay(node).hasOnly(userActivity),
       cssClasses: this.userActivityStyles.getCssClasses(userActivity),
       label: (node: TestNavigatorTreeNode) => this.userActivityLabeler.getLabel({
-        users: node.activities.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node).getUsers(userActivity),
+        users: node.activities.withoutBetterFittingNodeForDisplay(node).getUsers(userActivity),
         activityType: userActivity,
         forChildElement: node.type === ElementType.Folder
       })

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -26,7 +26,7 @@ import { TestNavigatorFieldSetup, TEST_NAVIGATOR_USER_ACTIVITY_LABEL_PROVIDER, T
 import { TestNavigatorComponent } from './test-navigator.component';
 import { AtomicUserActivitySet } from './user-activity-set';
 
-fdescribe('TestNavigatorComponent', () => {
+describe('TestNavigatorComponent', () => {
   const SAMPLE_ACTIVITY = 'sample.activity';
   let component: TestNavigatorComponent;
   let fixture: ComponentFixture<TestNavigatorComponent>;
@@ -1054,11 +1054,11 @@ fdescribe('TestNavigatorComponent', () => {
     // when
     messageBus.publish(USER_ACTIVITY_UPDATED, collaboratorActivities);
     tick();
-    fixture.detectChanges();
 
     // then
     expect(component.model.activities.getTypes('src/test/java/subfolder/newfolder/newfile.ext')).toContain('created.file');
     expect(component.model.activities.getUsers('created.file')).toContain('Jane Doe');
+    expect(subfolder.id).toEqual('src/test/java/subfolder');
     expect(subfolder.activities.getTypes('src/test/java/subfolder/newfolder/newfile.ext')).toContain('created.file');
     expect(subfolder.activities.getUsers('created.file', 'src/test/java/subfolder/newfolder/newfile.ext')).toContain('Jane Doe');
   })));
@@ -1081,12 +1081,13 @@ fdescribe('TestNavigatorComponent', () => {
     // then
     expect(component.model.activities.getTypes('src/test/java/subfolder/newfolder/newfile.ext').length).toEqual(0);
     expect(component.model.activities.getUsers('created.file').length).toEqual(0);
+    expect(subfolder.id).toEqual('src/test/java/subfolder');
     expect(subfolder.activities.getTypes('src/test/java/subfolder/newfolder/newfile.ext').length).toEqual(0);
     expect(subfolder.activities.getUsers('created.file', 'src/test/java/subfolder/newfolder/newfile.ext').length).toEqual(0);
   })));
 
 
-  it('shows icon and tooltip on parent when no closer ancestor node is visible',
+  it('shows icon and tooltip on parent when no closer ancestor node for the event is visible',
   fakeAsync(inject([MessagingService], async (messageBus: MessagingService) => {
     // given
     await component.updateModel();
@@ -1109,7 +1110,7 @@ fdescribe('TestNavigatorComponent', () => {
     expect(workspaceRootActivityIcon.nativeElement.title).toEqual('one or more collaborators are currently working on this');
   })));
 
-  it('does not show icon and tooltip on parent when closer ancestor node is visible',
+  it('does NOT show icon and tooltip on parent when closer ancestor node for the event is visible',
   fakeAsync(inject([MessagingService], async (messageBus: MessagingService) => {
     // given
     await component.updateModel();

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -26,7 +26,7 @@ import { TestNavigatorFieldSetup, TEST_NAVIGATOR_USER_ACTIVITY_LABEL_PROVIDER, T
 import { TestNavigatorComponent } from './test-navigator.component';
 import { AtomicUserActivitySet } from './user-activity-set';
 
-describe('TestNavigatorComponent', () => {
+fdescribe('TestNavigatorComponent', () => {
   const SAMPLE_ACTIVITY = 'sample.activity';
   let component: TestNavigatorComponent;
   let fixture: ComponentFixture<TestNavigatorComponent>;
@@ -1085,4 +1085,50 @@ describe('TestNavigatorComponent', () => {
     expect(subfolder.activities.getUsers('created.file', 'src/test/java/subfolder/newfolder/newfile.ext').length).toEqual(0);
   })));
 
+
+  it('shows icon and tooltip on parent when no closer ancestor node is visible',
+  fakeAsync(inject([MessagingService], async (messageBus: MessagingService) => {
+    // given
+    await component.updateModel();
+    component.model.expanded = true;
+    const collaboratorActivities: ElementActivity[] = [
+      {element: 'src/test/java/newDir/newFile.tcl', activities: [{ user: 'John Doe', type: SAMPLE_ACTIVITY}]}
+    ];
+
+    // when
+    messageBus.publish(USER_ACTIVITY_UPDATED, collaboratorActivities);
+    tick();
+    fixture.detectChanges();
+
+    // then
+    const workspaceRootActivityIcon = fixture.debugElement.query(By.css(
+      'div.indicator-boxes > div:nth-child(2) > app-indicator-box > div'));
+    expect(workspaceRootActivityIcon.nativeElement.classList).toContain('fa');
+    expect(workspaceRootActivityIcon.nativeElement.classList).toContain('fa-user');
+    expect(workspaceRootActivityIcon.nativeElement.classList).toContain('user-activity');
+    expect(workspaceRootActivityIcon.nativeElement.title).toEqual('one or more collaborators are currently working on this');
+  })));
+
+  it('does not show icon and tooltip on parent when closer ancestor node is visible',
+  fakeAsync(inject([MessagingService], async (messageBus: MessagingService) => {
+    // given
+    await component.updateModel();
+    component.model.expanded = true;
+    const collaboratorActivities: ElementActivity[] = [
+      {element: 'src/test/java/subfolder/file-with-closer-ancestor.tcl', activities: [{ user: 'John Doe', type: SAMPLE_ACTIVITY}]}
+    ];
+
+    // when
+    messageBus.publish(USER_ACTIVITY_UPDATED, collaboratorActivities);
+    tick();
+    fixture.detectChanges();
+
+    // then
+    const workspaceRootActivityIcon = fixture.debugElement.query(By.css(
+      'div.indicator-boxes > div:nth-child(2) > app-indicator-box > div'));
+    expect(workspaceRootActivityIcon.nativeElement.classList).not.toContain('fa');
+    expect(workspaceRootActivityIcon.nativeElement.classList).not.toContain('fa-user');
+    expect(workspaceRootActivityIcon.nativeElement.classList).not.toContain('user-activity');
+    expect(workspaceRootActivityIcon.nativeElement.title).toBeFalsy();
+  })));
 });

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -149,7 +149,7 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
           pathSegments.pop();
           const ancestorNodeId = pathSegments.join('/');
           if (treeNodeMap.has(ancestorNodeId)) {
-            treeNodeMap.get(ancestorNodeId).setDescendantActivity(nodeId, new AtomicUserActivitySet(activitiesMap.get(nodeId)));
+            treeNodeMap.get(ancestorNodeId).setAncestorsAcitivties(nodeId, new AtomicUserActivitySet(activitiesMap.get(nodeId)));
             break;
           }
         }

--- a/src/app/modules/test-navigator/test-navigator.component.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.ts
@@ -132,11 +132,26 @@ export class TestNavigatorComponent implements OnInit, OnDestroy {
         }
       });
 
+      const treeNodeMap = new Map<string, TestNavigatorTreeNode>();
       this.model.forEach((node) => {
+        treeNodeMap.set(node.id, node);
         if (activitiesMap.has(node.id)) {
           node.activities = new AtomicUserActivitySet(activitiesMap.get(node.id));
+          activitiesMap.delete(node.id);
         } else {
           node.activities = EMPTY_USER_ACTIVITY_SET;
+        }
+      });
+
+      activitiesMap.forEach((activity, nodeId) => {
+        const pathSegments = nodeId.split('/');
+        while (pathSegments.length > 0) {
+          pathSegments.pop();
+          const ancestorNodeId = pathSegments.join('/');
+          if (treeNodeMap.has(ancestorNodeId)) {
+            treeNodeMap.get(ancestorNodeId).setDescendantActivity(nodeId, new AtomicUserActivitySet(activitiesMap.get(nodeId)));
+            break;
+          }
         }
       });
     });

--- a/src/app/modules/test-navigator/user-activity-set.spec.ts
+++ b/src/app/modules/test-navigator/user-activity-set.spec.ts
@@ -6,10 +6,10 @@ describe('CompositeUserActivitySet', () => {
   describe('getTypes', () => {
     it('should return an empty list if the provided element is not known to the set', () => {
       // given
-      const activtySetUnderTest = new CompositeUserActivitySet();
+      const activitySetUnderTest = new CompositeUserActivitySet();
 
       // when
-      const actualTypes = activtySetUnderTest.getTypes('arbitrary unknown element');
+      const actualTypes = activitySetUnderTest.getTypes('arbitrary unknown element');
 
       // then
       expect(actualTypes).toBeTruthy();
@@ -31,8 +31,8 @@ describe('CompositeUserActivitySet', () => {
     });
   });
 
-  describe('filterVisibleCloserAncestors', () => {
-    it('should filter only activities with invalid paths from set if the given node is collapsed', () => {
+  describe('ownAndChildActivitiesWithNoVisibleCloserAncestorNode', () => {
+    it('should filter out only activities with invalid paths from set if the given node is collapsed', () => {
       // given
       const activtySetUnderTest = new CompositeUserActivitySet();
       activtySetUnderTest.set('iam/root', new AtomicUserActivitySet([{type: 'sampleActivity', user: ''}]));
@@ -47,7 +47,7 @@ describe('CompositeUserActivitySet', () => {
       treeNode.expanded = false;
 
       // whwen
-      const actualfilteredSet = activtySetUnderTest.filterVisibleCloserAncestors(treeNode);
+      const actualfilteredSet = activtySetUnderTest.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(treeNode);
 
       // then
       expect(actualfilteredSet.getTypes('iam/root')).toContain('sampleActivity');
@@ -56,7 +56,7 @@ describe('CompositeUserActivitySet', () => {
       expect(actualfilteredSet.getTypes('not/a_valid_child_of/iam/root').length).toEqual(0);
     });
 
-    it('should filter activities that have a closer ancestor node among the children of the given node', () => {
+    it('should filter out activities that have an ancestor node closer to the event node among the children of the given tree node', () => {
       // given
       const activtySetUnderTest = new CompositeUserActivitySet();
       activtySetUnderTest.set('iam/root', new AtomicUserActivitySet([{type: 'sampleActivity', user: ''}]));
@@ -71,7 +71,7 @@ describe('CompositeUserActivitySet', () => {
       treeNode.expanded = true;
 
       // whwen
-      const actualfilteredSet = activtySetUnderTest.filterVisibleCloserAncestors(treeNode);
+      const actualfilteredSet = activtySetUnderTest.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(treeNode);
 
       // then
       expect(actualfilteredSet.getTypes('iam/root')).toContain('sampleActivity');

--- a/src/app/modules/test-navigator/user-activity-set.spec.ts
+++ b/src/app/modules/test-navigator/user-activity-set.spec.ts
@@ -47,7 +47,7 @@ describe('CompositeUserActivitySet', () => {
       treeNode.expanded = false;
 
       // whwen
-      const actualfilteredSet = activtySetUnderTest.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(treeNode);
+      const actualfilteredSet = activtySetUnderTest.withoutBetterFittingNodeForDisplay(treeNode);
 
       // then
       expect(actualfilteredSet.getTypes('iam/root')).toContain('sampleActivity');
@@ -71,7 +71,7 @@ describe('CompositeUserActivitySet', () => {
       treeNode.expanded = true;
 
       // whwen
-      const actualfilteredSet = activtySetUnderTest.ownAndChildActivitiesWithNoVisibleCloserAncestorNode(treeNode);
+      const actualfilteredSet = activtySetUnderTest.withoutBetterFittingNodeForDisplay(treeNode);
 
       // then
       expect(actualfilteredSet.getTypes('iam/root')).toContain('sampleActivity');

--- a/src/app/modules/test-navigator/user-activity-set.spec.ts
+++ b/src/app/modules/test-navigator/user-activity-set.spec.ts
@@ -1,0 +1,32 @@
+import { CompositeUserActivitySet } from "./user-activity-set";
+
+describe('CompositeUserActivitySet', () => {
+  describe('getTypes', () => {
+    it('should return an empty list if the provided element is not known to the set', () => {
+      // given
+      const activtySetUnderTest = new CompositeUserActivitySet();
+
+      // when
+      const actualTypes = activtySetUnderTest.getTypes('arbitrary unknown element');
+
+      // then
+      expect(actualTypes).toBeTruthy();
+      expect(actualTypes.length).toEqual(0);
+    });
+  });
+
+  describe('getUsers', () => {
+    it('should return an empty list if the provided element is not known to the set', () => {
+      // given
+      const activtySetUnderTest = new CompositeUserActivitySet();
+
+      // when
+      const actualTypes = activtySetUnderTest.getUsers('arbitrary activity', 'arbitrary unknown element');
+
+      // then
+      expect(actualTypes).toBeTruthy();
+      expect(actualTypes.length).toEqual(0);
+    });
+  });
+
+});

--- a/src/app/modules/test-navigator/user-activity-set.ts
+++ b/src/app/modules/test-navigator/user-activity-set.ts
@@ -48,13 +48,21 @@ export class CompositeUserActivitySet implements UserActivitySet {
 
   constructor() {}
 
+  clear() {
+    this.elementActivityMap.clear();
+  }
+
   set(element: string, uaSet: UserActivitySet) {
     this.elementActivityMap.set(element, uaSet);
   }
 
   getUsers(type: string, element?: string): string[] {
     if (element) {
-      return this.elementActivityMap.get(element).getUsers(type);
+      if (this.elementActivityMap.has(element)) {
+        return this.elementActivityMap.get(element).getUsers(type);
+      } else {
+        return [];
+      }
     } else {
     return [].concat(...this.children.map((uaSet) => uaSet.getUsers(type))).filter(this.unique);
     }
@@ -62,7 +70,11 @@ export class CompositeUserActivitySet implements UserActivitySet {
 
   getTypes(element?: string): string[] {
     if (element) {
-      return this.elementActivityMap.get(element).getTypes();
+      if (this.elementActivityMap.has(element)) {
+        return this.elementActivityMap.get(element).getTypes();
+      } else {
+        return [];
+      }
     } else {
       return [].concat(...this.children.map((uaSet) => uaSet.getTypes())).filter(this.unique);
     }

--- a/src/app/modules/test-navigator/user-activity-set.ts
+++ b/src/app/modules/test-navigator/user-activity-set.ts
@@ -5,7 +5,7 @@ export interface UserActivitySet {
   getUsers(type: string, element?: string): string[];
   getTypes(element?: string): string[];
   hasOnly(type: string, element?: string): boolean;
-  ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node: TestNavigatorTreeNode): UserActivitySet;
+  withoutBetterFittingNodeForDisplay(node: TestNavigatorTreeNode): UserActivitySet;
 }
 
 export class AtomicUserActivitySet implements UserActivitySet {
@@ -33,7 +33,7 @@ export class AtomicUserActivitySet implements UserActivitySet {
     return this.activities.has(type) && this.activities.size < 2;
   }
 
-  ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node: TestNavigatorTreeNode): UserActivitySet {
+  withoutBetterFittingNodeForDisplay(node: TestNavigatorTreeNode): UserActivitySet {
     return this;
   }
 
@@ -107,7 +107,7 @@ export class CompositeUserActivitySet implements UserActivitySet {
    * one.
    * @param node a tree node providing the viewpoint for filtering the activities.
    */
-  ownAndChildActivitiesWithNoVisibleCloserAncestorNode(node: TestNavigatorTreeNode): UserActivitySet {
+  withoutBetterFittingNodeForDisplay(node: TestNavigatorTreeNode): UserActivitySet {
     const nodePath = node.id;
     const nodeDepth = nodePath.split('/').length;
     return new CompositeUserActivitySet(Array.from(this.elementActivityMap).filter(([activityPath, _]) => {


### PR DESCRIPTION
User activities signalling the creation of new elements, or activities referring to elements that were locally deleted, should still appear in the navigation tree: in the parent node, or the closest existing ancestor node.

With this PR, for all user activities that do not have directly corresponding tree nodes, their clostest ancestor is searched for in the tree. When found, they are added to their ancestor nodes (going up recursively until the root is reached).
Also, on a user activity update, the previously stored user activities are completely cleared before adding new values, to ensure that no stale markers remain.

This PR incorporates PR #55, and will get more managable in size if that one is merged first.
PR #55 in turn depends on https://github.com/test-editor/web-testeditor-commons/pull/32.