### PR TITLE
Fix/parent rename

### DIFF
--- a/src/app/modules/model/test-navigator-tree-node.ts
+++ b/src/app/modules/model/test-navigator-tree-node.ts
@@ -137,7 +137,11 @@ export class TestNavigatorTreeNode extends TreeNode {
   }
 
   get id(): string {
-    return this.workspaceElement.path;
+    let result = this.workspaceElement.path;
+    if (this.parent) {
+      result = this.parent.id + '/' + this.name;
+    }
+    return result;
   }
 
   get activities(): UserActivitySet {

--- a/src/app/modules/test-navigator/test-navigator.component.spec.ts
+++ b/src/app/modules/test-navigator/test-navigator.component.spec.ts
@@ -32,6 +32,17 @@ describe('TestNavigatorComponent', () => {
   const SUBFOLDER_DOM_INDEX = 1;
   const TCL_FILE_DOM_INDEX = 2;
   const RENAME_FOLDER_DOM_INDEX = 4;
+  const dirTree = () => ({
+    name: 'root', path: 'src/test/java', type: ElementType.Folder, children: [
+      {name: 'test.tcl', path: 'src/test/java/test.tcl', type: ElementType.File, children: []},
+      {name: 'test.tsl', path: 'src/test/java/test.tsl', type: ElementType.File, children: []},
+      {name: 'subfolder', path: 'src/test/java/subfolder', type: ElementType.Folder, children: []},
+      {name: 'zRenameMe', path: 'src/test/java/zRenameMe', type: ElementType.Folder, children: [
+        {name: 'nestedFile.tcl', path: 'src/test/java/zRenameMe/nestedFile.tcl', type: ElementType.File, children: []},
+      ]},
+    ]});
+
+
   let component: TestNavigatorComponent;
   let fixture: ComponentFixture<TestNavigatorComponent>;
   let mockFilenameValidator: FilenameValidator;
@@ -50,15 +61,7 @@ describe('TestNavigatorComponent', () => {
 
     mockFilenameValidator = mock(FilenameValidator);
     when(mockFilenameValidator.isValidName(anyString(), anything())).thenReturn(true);
-    when(mockPersistenceService.listFiles()).thenResolve({
-      name: 'root', path: 'src/test/java', type: ElementType.Folder, children: [
-        {name: 'test.tcl', path: 'src/test/java/test.tcl', type: ElementType.File, children: []},
-        {name: 'test.tsl', path: 'src/test/java/test.tsl', type: ElementType.File, children: []},
-        {name: 'subfolder', path: 'src/test/java/subfolder', type: ElementType.Folder, children: []},
-        {name: 'zRenameMe', path: 'src/test/java/zRenameMe', type: ElementType.Folder, children: [
-          {name: 'nestedFile.tcl', path: 'src/test/java/zRenameMe/nestedFile.tcl', type: ElementType.File, children: []},
-        ]},
-      ]});
+    when(mockPersistenceService.listFiles()).thenResolve(dirTree());
     when(mockPersistenceService.deleteResource(anyString())).thenResolve('');
     when(mockPersistenceService.renameResource(anyString(), anyString())).thenResolve('');
     when(mockPersistenceService.createResource(anyString(), anything())).thenResolve('');
@@ -360,7 +363,7 @@ describe('TestNavigatorComponent', () => {
        clickDeleteAndConfirmOnFirstNode();
 
        // then
-       expect(component.model.children.length).toEqual(2);
+       expect(component.model.children.length).toEqual(dirTree().children.length - 1);
        expect(component.model.children[1].name).not.toEqual(elementBeingDeleted.name);
      }));
 
@@ -377,7 +380,7 @@ describe('TestNavigatorComponent', () => {
        clickDeleteAndConfirmOnFirstNode();
 
        // then
-       expect(component.model.children.length).toEqual(3);
+       expect(component.model.children.length).toEqual(dirTree().children.length);
        expect(component.model.children[1].name).toEqual(elementFailingToBeDeleted.name);
        expect(fixture.debugElement.query(By.css('#errorMessage')).nativeElement.innerText).toEqual('Error while deleting element!');
        flush();
@@ -714,7 +717,7 @@ describe('TestNavigatorComponent', () => {
     expect(component.model.children[0].children[0].name).toEqual('test.tcl');
     expect(component.model.children[0].children[0].id).toEqual('src/test/java/subfolder/test.tcl');
     expect(component.model.children[1].name).toEqual('test.tsl');
-    expect(component.model.children.length).toEqual(2);
+    expect(component.model.children.length).toEqual(dirTree().children.length - 1);
     expect(component.hasCuttedNodeInClipboard()).toBeFalsy();
     expect(component.hasCopiedNodeInClipboard()).toBeFalsy();
   }));
@@ -743,7 +746,7 @@ describe('TestNavigatorComponent', () => {
 
     // then
     expect(component.model.children[0].children.length).toEqual(0);
-    expect(component.model.children.length).toEqual(3);
+    expect(component.model.children.length).toEqual(dirTree().children.length);
     expect(component.hasCuttedNodeInClipboard()).toBeFalsy();
     expect(component.hasCopiedNodeInClipboard()).toBeTruthy();
   }));

--- a/src/app/modules/test-navigator/user-activity-set.spec.ts
+++ b/src/app/modules/test-navigator/user-activity-set.spec.ts
@@ -65,8 +65,8 @@ describe('CompositeUserActivitySet', () => {
       activtySetUnderTest.set('not/a_valid_child_of/iam/root', new AtomicUserActivitySet([{type: 'sampleActivity', user: ''}]));
       const treeNode = new TestNavigatorTreeNode({
         name: 'root', path: 'iam/root', type: ElementType.Folder, children: [
-          { name: 'element1', path: 'iam/root/an_element', type: ElementType.Folder, children: [] },
-          { name: 'element2', path: 'iam/root/closer_ancestor', type: ElementType.Folder, children: []}]
+          { name: 'an_element', path: 'iam/root/an_element', type: ElementType.Folder, children: [] },
+          { name: 'closer_ancestor', path: 'iam/root/closer_ancestor', type: ElementType.Folder, children: []}]
       });
       treeNode.expanded = true;
 
@@ -75,9 +75,9 @@ describe('CompositeUserActivitySet', () => {
 
       // then
       expect(actualfilteredSet.getTypes('iam/root')).toContain('sampleActivity');
-      expect(actualfilteredSet.getTypes('iam/root/closer_ancestor/of/this').length).toEqual(0);
+      expect(actualfilteredSet.getTypes('iam/root/closer_ancestor/of/this').length).toEqual(0, 'closer ancestor was not filtered out!');
       expect(actualfilteredSet.getTypes('iam/root/non_existing')).toContain('sampleActivity');
-      expect(actualfilteredSet.getTypes('not/a_valid_child_of/iam/root').length).toEqual(0);
+      expect(actualfilteredSet.getTypes('not/a_valid_child_of/iam/root').length).toEqual(0, 'invalid child node was not filtered out!');
     });
   });
 


### PR DESCRIPTION
The IDs of `TestNavigatorTreeNode`s are now derived from the parent node, as opposed to relying on the `path` field of the underlying raw `WorkspaceElement`. This way, when a directory is renamed, the change does not have to be propagated down into all nodes of the whole subtree (which we did not do so far, either, leading to buggy behavior when handling nodes below a renamed one).

This also means that the `path` field values of workspace elements, as reported from the backend, willl all be ignored, except for the value at the root.